### PR TITLE
Fix `alpha` attribute in LRN

### DIFF
--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -90,10 +90,11 @@ def convert_FixedBatchNormalization(func, onnx_op_name, opset_version, input_nam
 
 def convert_LocalResponseNormalization(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     if opset_version == 1:
+        size = int(func.n)
         return helper.make_node(
             onnx_op_name, input_names, output_names,
-            alpha=float(func.alpha),
+            alpha=float(func.alpha) * size,
             beta=float(func.beta),
             bias=float(func.k),
-            size=int(func.n),
+            size=size,
         ),

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -11,6 +11,13 @@ from chainer import testing
 from onnx_chainer.testing import test_mxnet
 
 
+def _arange(*shape):
+    r = 1
+    for d in shape:
+        r *= d
+    return np.arange(r).reshape(shape).astype(np.float32)
+
+
 @testing.parameterize(
     {
         'name': 'local_response_normalization',
@@ -37,7 +44,7 @@ class TestNormalizations(unittest.TestCase):
 
         ops = getattr(F, self.name)
         self.model = Model(ops, self.args, self.input_argname)
-        self.x = np.zeros((1, 5, 3, 3), dtype=np.float32)
+        self.x = _arange(1, 5, 3, 3)
         self.fn = self.name + '.onnx'
 
     def test_compatibility(self):
@@ -68,7 +75,7 @@ class TestBatchNormalization(unittest.TestCase):
                 return self.bn(x)
 
         self.model = Model()
-        self.x = np.zeros((1, 5), dtype=np.float32)
+        self.x = _arange(1, 5)
         self.fn = 'BatchNormalization.onnx'
 
     def test_compatibility(self):

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -12,9 +12,7 @@ from onnx_chainer.testing import test_mxnet
 
 
 def _arange(*shape):
-    r = 1
-    for d in shape:
-        r *= d
+    r = np.prod(shape)
     return np.arange(r).reshape(shape).astype(np.float32)
 
 


### PR DESCRIPTION
ONNX uses `alpha / size` as the scaling parameter while
Chainer uses `alpha`.

https://github.com/onnx/onnx/blob/master/docs/Operators.md#LRN

This issue was not caught since we were using np.zeros to test
the converted ONNX model. A simple np.arange wrapper was
introduced to generate a deterministic but more interesting
array than np.zeros.