### PR TITLE
Keep average pooling 2d compatibility

### DIFF
--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -3,7 +3,9 @@ from onnx import helper
 
 def convert_AveragePooling2D(
         func, onnx_op_name, opset_version, input_names, output_names, parameters):
-    if opset_version == 1 or opset_version == 7:
+    if opset_version == 1:
+        raise ValueError('AveragePooling2D is not compatible with ONNX\'s AveragePool-1. Use operation set version >= 7.')
+    elif opset_version == 7:
         return helper.make_node(
             onnx_op_name, input_names, output_names,
             kernel_shape=(func.kh, func.kw),
@@ -73,4 +75,3 @@ def convert_MaxPoolingND(func, onnx_op_name, opset_version, input_names, output_
             strides=func.stride,
             storage_order=0,  # row major
         ),
-

--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -10,7 +10,8 @@ def convert_AveragePooling2D(
             onnx_op_name, input_names, output_names,
             kernel_shape=(func.kh, func.kw),
             pads=(func.ph, func.pw, func.ph, func.pw),
-            strides=(func.sy, func.sx)
+            strides=(func.sy, func.sx),
+            count_include_pad=1,
         ),
 
 

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -13,6 +13,8 @@ from onnx_chainer.testing import test_onnxruntime
 @testing.parameterize(
     {'name': 'average_pooling_2d', 'ops': F.average_pooling_2d,
      'in_shape': (1, 3, 6, 6), 'args': [2, 1, 0]},
+    {'name': 'average_pooling_2d', 'ops': F.average_pooling_2d,
+     'in_shape': (1, 3, 6, 6), 'args': [3, 2, 1]},
     {'name': 'average_pooling_nd', 'ops': F.average_pooling_nd,
      'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 0]},
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,


### PR DESCRIPTION
[`chainer.functions.average_pooling_2d`](https://docs.chainer.org/en/stable/reference/generated/chainer.functions.average_pooling_2d.html) can't ignore zero padded region. 

~~~~
[chainer.functions.average_pooling_2d]
                         0 0 0
1 1     --padding-->     0 1 1     --3x3 pooling-->     0.44444
1 1                      0 1 1
~~~~

[`AveragePool`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#AveragePool) ignores padded region when `count_include_pad=0` (default). [`AveragePool-1`](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#AveragePool-1) too. In addition, `AveragePool-1` does not have `count_include_pad` attribute.

~~~~
[AveragePool(count_include_pad=0) or AveragePool-1]
                         0 0 0
1 1     --padding-->     0 1 1     --3x3 pooling-->     1
1 1                      0 1 1

[AveragePool(count_include_pad=1)]
                         0 0 0
1 1     --padding-->     0 1 1     --3x3 pooling-->     0.44444
1 1                      0 1 1
~~~~

So, current `AveragePooling2D` conversions

* `AveragePooling2D` -> `AveragePool(count_include_pad=0,default)`
* `AveragePooling2D` -> `AveragePool-1`

are incompatible conversion.

This PR allows compatible conversion

* `AveragePooling2D` -> `AveragePool(count_include_pad=1)`

and forbids incompatibles.