### PR TITLE
WIP: do not broacast constant value when export

### DIFF
--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -16,17 +16,17 @@ def convert_Add(func, onnx_op_name, opset_version, input_names, output_names, pa
 
 def convert_AddConstant(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(str(id(value_param)))
 
     if opset_version == 1:
         return helper.make_node(
-            onnx_op_name, input_names, output_names, consumed_inputs=[1, 1]),
-    elif opset_version == 6 or opset_version == 7:
+            onnx_op_name, input_names, output_names, consumed_inputs=[1, 1], broadcast=1),
+    elif opset_version == 6:
+        return helper.make_node(onnx_op_name, input_names, output_names, broadcast=1),
+    elif opset_version == 7:
         return helper.make_node(onnx_op_name, input_names, output_names),
-
 
 def convert_Sub(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     if opset_version == 1:
@@ -43,27 +43,27 @@ def convert_Mul(func, onnx_op_name, opset_version, input_names, output_names, pa
 
 def convert_MulConstant(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(str(id(value_param)))
 
     if opset_version == 1:
-        return helper.make_node(onnx_op_name, input_names, output_names, consumed_inputs=[1, 1]),
-    elif opset_version == 6 or opset_version == 7:
+        return helper.make_node(onnx_op_name, input_names, output_names, consumed_inputs=[1, 1], broadcast=1),
+    elif opset_version == 6:
+        return helper.make_node(onnx_op_name, input_names, output_names, broadcast=1),
+    elif opset_version == 7:
         return helper.make_node(onnx_op_name, input_names, output_names),
 
 
 def convert_MulConstant(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(str(id(value_param)))
 
     if opset_version == 1:
         return helper.make_node(
-            onnx_op_name, input_names, output_names, consumed_inputs=[1, 1]),
+            onnx_op_name, input_names, output_names, consumed_inputs=[1, 1], broadcast=1),
     elif opset_version == 6 or opset_version == 7:
         return helper.make_node(onnx_op_name, input_names, output_names),
 
@@ -91,12 +91,13 @@ def convert_Absolute(func, onnx_op_name, opset_version, input_names, output_name
 
 def convert_PowVarConst(func, onnx_op_name, opset_version, input_names, output_names, parameters):
     value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(str(id(value_param)))
 
-    if opset_version == 1 or opset_version == 7:
+    if opset_version == 1:
+        return helper.make_node(onnx_op_name, input_names, output_names, broadcast=1),
+    elif opset_version == 7:
         return helper.make_node(onnx_op_name, input_names, output_names),
 
 


### PR DESCRIPTION
This makes ONNX files smaller and more flexible at the cost of requiring inference backends to support broadcasting,

Note that [Menoh](https://github.com/pfnet-research/menoh) do not support broadcasting yet.
cc: @okdshin 