### PR TITLE
Support cover_all options

### DIFF
--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -18,12 +18,7 @@ def convert_AveragePooling2D(
 
 
 def convert_AveragePoolingND(func, onnx_op_name, opset_version, input_names, output_names, parameters):
-    pad = []
-    x_ndim = len(func.inputs[0].shape)
-    k_ndim = len(func.ksize)
-    for _ in range(x_ndim - k_ndim):
-        pad.append(0)
-    pad.extend(func.pad)
+    pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
@@ -49,26 +44,21 @@ def convert_MaxPooling2D(func, onnx_op_name, opset_version, input_names, output_
         return helper.make_node(
             onnx_op_name, input_names, output_names,
             kernel_shape=(func.kh, func.kw),
-            pads=(func.ph, func.pw, func.ph, func.pw),
+            pads=(func.ph, func.pw, func.ph + dph, func.pw + dpw),
             strides=(func.sy, func.sx)
         ),
     elif opset_version == 8:
         return helper.make_node(
             onnx_op_name, input_names, output_names,
             kernel_shape=(func.kh, func.kw),
-            pads=(func.ph, func.pw, func.ph, func.pw),
+            pads=(func.ph, func.pw, func.ph + dph, func.pw + dpw),
             strides=(func.sy, func.sx),
             storage_order=0,  # row major
         ),
 
 
 def convert_MaxPoolingND(func, onnx_op_name, opset_version, input_names, output_names, parameters):
-    pad = []
-    x_ndim = len(func.inputs[0].shape)
-    k_ndim = len(func.ksize)
-    for _ in range(x_ndim - k_ndim):
-        pad.append(0)
-    pad.extend(func.pad)
+    pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
@@ -90,4 +80,3 @@ def convert_MaxPoolingND(func, onnx_op_name, opset_version, input_names, output_
             strides=func.stride,
             storage_order=0,  # row major
         ),
-

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -12,13 +12,13 @@ from onnx_chainer.testing import test_onnxruntime
 
 @testing.parameterize(
     {'name': 'average_pooling_2d', 'ops': F.average_pooling_2d,
-     'in_shape': (1, 3, 6, 6), 'args': [2, 1, 0]},
+     'in_shape': (1, 3, 6, 5), 'args': [2, 2, 0]},
     {'name': 'average_pooling_nd', 'ops': F.average_pooling_nd,
-     'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 0]},
+     'in_shape': (1, 3, 6, 5, 4), 'args': [2, 2, 0]},
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
-     'in_shape': (1, 3, 6, 6), 'args': [2, 1, 0]},
+     'in_shape': (1, 3, 6, 5), 'args': [2, 2, 0]},
     {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
-     'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 0]},
+     'in_shape': (1, 3, 6, 5, 4), 'args': [2, 2, 0]},
 )
 class TestPoolings(unittest.TestCase):
 

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -18,8 +18,12 @@ from onnx_chainer.testing import test_onnxruntime
      'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 1], 'cover_all': None},
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
      'in_shape': (1, 3, 6, 6), 'args': [2, 1, 1], 'cover_all': False},
+    {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
+     'in_shape': (1, 3, 6, 5), 'args': [3, 1, 1], 'cover_all': True},
     {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
      'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 1], 'cover_all': False},
+    {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
+     'in_shape': (1, 3, 6, 5, 4), 'args': [3, 1, 1], 'cover_all': True},
 )
 class TestPoolings(unittest.TestCase):
 
@@ -35,6 +39,29 @@ class TestPoolings(unittest.TestCase):
                 onnx.defs.onnx_opset_version() + 1):
             test_onnxruntime.check_output(
                 self.model, self.x, self.fn, opset_version=opset_version)
+
+
+@testing.parameterize(
+    {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
+     'in_shape': (1, 3, 6, 6), 'args': [2, 2, 1], 'cover_all': True},
+    {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
+     'in_shape': (1, 3, 6, 6, 6), 'args': [2, 2, 1], 'cover_all': True},
+)
+class TestPoolingsWithUnsupportedSettings(unittest.TestCase):
+
+    def setUp(self):
+        ops = getattr(F, self.name)
+        self.model = Model(ops, self.args, self.cover_all)
+        self.x = np.ones(self.in_shape, dtype=np.float32)
+        self.fn = self.name + '.onnx'
+
+    def test_output(self):
+        for opset_version in range(
+                test_onnxruntime.MINIMUM_OPSET_VERSION,
+                onnx.defs.onnx_opset_version() + 1):
+            with self.assertRaises(RuntimeError):
+                test_onnxruntime.check_output(
+                    self.model, self.x, self.fn, opset_version=opset_version)
 
 
 class Model(chainer.Chain):

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -43,9 +43,9 @@ class TestPoolings(unittest.TestCase):
 
 @testing.parameterize(
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
-     'in_shape': (1, 3, 6, 6), 'args': [2, 2, 1], 'cover_all': True},
+     'in_shape': (1, 3, 6, 5), 'args': [2, 2, 1], 'cover_all': True},
     {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
-     'in_shape': (1, 3, 6, 6, 6), 'args': [2, 2, 1], 'cover_all': True},
+     'in_shape': (1, 3, 6, 5, 4), 'args': [2, 2, 1], 'cover_all': True},
 )
 class TestPoolingsWithUnsupportedSettings(unittest.TestCase):
 


### PR DESCRIPTION
This PR supports `cover_all` options in `MaxPooling2D`, and `MaxPoolingND`.
- [x] Support pooling functions
- [x] Write tests for pooling functions