### PR TITLE
Fix to accept chainer.Variable collection input

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -209,13 +209,13 @@ def export(model, args, filename=None, export_params=True,
         for i, arg in enumerate(args):
             if isinstance(arg, numpy.ndarray):
                 args[i] = chainer.Variable(arg)
-                network_inputs.append(args[i])
+            network_inputs.append(args[i])
         outputs = model(*args)
     elif isinstance(args, dict):
         for key, arg in args.items():
             if isinstance(arg, numpy.ndarray):
                 args[key] = chainer.Variable(arg)
-                network_inputs.append(args[key])
+            network_inputs.append(args[key])
         outputs = model(**args)
     elif isinstance(args, numpy.ndarray):
         args = chainer.Variable(args)

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -35,6 +35,9 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
         chainer_out = model(*x)
         x_rt = tuple(
             _x.array if isinstance(_x, chainer.Variable) else _x for _x in x)
+    elif isinstance(x, dict):
+        chainer_out = model(**x)
+        x_rt = tuple(_x.array if isinstance(_x, chainer.Variable) else _x for _, _x in x.items())
     elif isinstance(x, np.ndarray):
         chainer_out = model(chainer.Variable(x))
         x_rt = x,
@@ -43,9 +46,10 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
         x_rt = x.array,
     else:
         raise ValueError(
-            'The \'x\' argument should be a list or tuple of numpy.ndarray or '
-            'chainer.Variable, or simply a numpy.ndarray or a chainer.Variable'
-            ' itself. But a {} object was given.'.format(type(x)))
+            'The \'x\' argument should be a list, tuple or dict of '
+            'numpy.ndarray or chainer.Variable, or simply a numpy.ndarray or a'
+            ' chainer.Variable itself. But a {} object was given.'.format(
+                type(x)))
 
     if isinstance(chainer_out, (list, tuple)):
         chainer_out = (y.array for y in chainer_out)

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -37,7 +37,8 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
             _x.array if isinstance(_x, chainer.Variable) else _x for _x in x)
     elif isinstance(x, dict):
         chainer_out = model(**x)
-        x_rt = tuple(_x.array if isinstance(_x, chainer.Variable) else _x for _, _x in x.items())
+        x_rt = tuple(_x.array if isinstance(_x, chainer.Variable) else _x
+                     for _, _x in x.items())
     elif isinstance(x, np.ndarray):
         chainer_out = model(chainer.Variable(x))
         x_rt = x,

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -33,10 +33,14 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
         for i in x:
             assert isinstance(i, (np.ndarray, chainer.Variable))
         chainer_out = model(*x)
+        x_rt = tuple(
+            _x.array if isinstance(_x, chainer.Variable) else _x for _x in x)
     elif isinstance(x, np.ndarray):
         chainer_out = model(chainer.Variable(x))
+        x_rt = x,
     elif isinstance(x, chainer.Variable):
         chainer_out = model(x)
+        x_rt = x.array,
     else:
         raise ValueError(
             'The \'x\' argument should be a list or tuple of numpy.ndarray or '
@@ -70,7 +74,7 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
     assert input_names == list(sorted(graph_input_names))
 
     rt_out = sess.run(
-        None, {name: array for name, array in zip(input_names, x)})
+        None, {name: array for name, array in zip(input_names, x_rt)})
 
     for cy, my in zip(chainer_out, rt_out):
         np.testing.assert_almost_equal(cy, my, decimal=5)


### PR DESCRIPTION
By #65 , current exporter does not accept `chainer.Variable` collection such as tuple like `(chainer.Variable, chainer.Variable)`, and this PR fixes it along with adding tests (fixes #75)

This issue is found on [chainer-compiler](https://github.com/pfnet-research/chainer-compiler)'s test, for example [gen_mnist_mlp.py](https://github.com/pfnet-research/chainer-compiler/blob/4b9eb94b7671aba4b4ced1be23eabcb238035df0/scripts/gen_mnist_mlp.py), however, this PR resolve the failure partially (ref #80). I will fix it another PR later.