### PR TITLE
An attempt to improve the quality of test inputs

### DIFF
--- a/onnx_chainer/testing/input_generator.py
+++ b/onnx_chainer/testing/input_generator.py
@@ -1,0 +1,92 @@
+import numpy as np
+
+
+def shaped_range(*shape, dtype=np.float32):
+    r = np.arange(np.prod(shape))
+    r = r.reshape(shape)
+    return r
+
+
+def _increasing_impl(*shape, dtype=np.float32, negative=True, bias=0):
+    r = shaped_range(*shape, dtype=dtype)
+    if negative:
+        r -= r.size // 2
+    if dtype in (np.float32, np.float64):
+        r = r * 0.5
+    r += bias
+    return r.astype(dtype)
+
+
+def increasing(*shape, dtype=np.float32):
+    """Returns a monotonically increasing ndarray for test inputs.
+
+    The output will contain both zero, negative numbers, and non
+    integer numbers for float dtypes. A test writer is supposed to
+    consider this function first.
+
+    Example:
+
+    >>> increasing(3,4)
+    array([[-3. , -2.5, -2. , -1.5],
+           [-1. , -0.5,  0. ,  0.5],
+           [ 1. ,  1.5,  2. ,  2.5]], dtype=float32)
+
+    Args:
+      shape (tuple of int): The shape of the output array.
+      dtype (numpy.dtype): The dtype of the output array.
+
+    Returns:
+      numpy.ndarray
+    """
+    return _increasing_impl(*shape, dtype=dtype)
+
+
+def nonzero_increasing(*shape, dtype=np.float32, bias=1e-7):
+    """Returns a monotonically increasing ndarray for test inputs.
+
+    Similar to `increasing` but contains no zeros. Expected to be used
+    for divisors.
+
+    Example:
+
+    >>> nonzero_increasing(3,4)
+    array([[-3.0000000e+00, -2.5000000e+00, -1.9999999e+00, -1.4999999e+00],
+           [-9.9999988e-01, -4.9999991e-01,  1.0000000e-07,  5.0000012e-01],
+           [ 1.0000001e+00,  1.5000001e+00,  2.0000000e+00,  2.5000000e+00]],
+          dtype=float32)
+
+    Args:
+      shape (tuple of int): The shape of the output array.
+      dtype (numpy.dtype): The dtype of the output array.
+      bias (float): The bias to avoid zero.
+
+    Returns:
+      numpy.ndarray
+    """
+    assert dtype in (np.float32, np.float64)
+    return _increasing_impl(*shape, dtype=dtype, bias=bias)
+
+
+def positive_increasing(*shape, dtype=np.float32, bias=1e-7):
+    """Returns a monotonically increasing ndarray for test inputs.
+
+    Similar to `increasing` but contains only positive numbers. Expected
+    to be used for `math.log`, `math.sqrt`, etc.
+
+    Example:
+
+    >>> positive_increasing(3,4)
+    array([[1.0000000e-07, 5.0000012e-01, 1.0000001e+00, 1.5000001e+00],
+           [2.0000000e+00, 2.5000000e+00, 3.0000000e+00, 3.5000000e+00],
+           [4.0000000e+00, 4.5000000e+00, 5.0000000e+00, 5.5000000e+00]],
+          dtype=float32)
+
+    Args:
+      shape (tuple of int): The shape of the output array.
+      dtype (numpy.dtype): The dtype of the output array.
+      bias (float): The bias to avoid zero.
+
+    Returns:
+      numpy.ndarray
+    """
+    return _increasing_impl(*shape, dtype=dtype, negative=False, bias=bias)

--- a/onnx_chainer/testing/input_generator.py
+++ b/onnx_chainer/testing/input_generator.py
@@ -26,7 +26,7 @@ def increasing(*shape, dtype=np.float32):
 
     Example:
 
-    >>> increasing(3,4)
+    >>> increasing(3, 4)
     array([[-3. , -2.5, -2. , -1.5],
            [-1. , -0.5,  0. ,  0.5],
            [ 1. ,  1.5,  2. ,  2.5]], dtype=float32)
@@ -49,7 +49,7 @@ def nonzero_increasing(*shape, dtype=np.float32, bias=1e-7):
 
     Example:
 
-    >>> nonzero_increasing(3,4)
+    >>> nonzero_increasing(3, 4)
     array([[-3.0000000e+00, -2.5000000e+00, -1.9999999e+00, -1.4999999e+00],
            [-9.9999988e-01, -4.9999991e-01,  1.0000000e-07,  5.0000012e-01],
            [ 1.0000001e+00,  1.5000001e+00,  2.0000000e+00,  2.5000000e+00]],
@@ -75,7 +75,7 @@ def positive_increasing(*shape, dtype=np.float32, bias=1e-7):
 
     Example:
 
-    >>> positive_increasing(3,4)
+    >>> positive_increasing(3, 4)
     array([[1.0000000e-07, 5.0000012e-01, 1.0000001e+00, 1.5000001e+00],
            [2.0000000e+00, 2.5000000e+00, 3.0000000e+00, 3.5000000e+00],
            [4.0000000e+00, 4.5000000e+00, 5.0000000e+00, 5.5000000e+00]],

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -88,4 +88,4 @@ def check_output(model, x, fn, out_key='prob', opset_version=None):
         None, {name: array for name, array in zip(input_names, x_rt)})
 
     for cy, my in zip(chainer_out, rt_out):
-        np.testing.assert_almost_equal(cy, my, decimal=5)
+        np.testing.assert_allclose(cy, my, rtol=1e-5, atol=1e-5)

--- a/tests/functions_tests/test_activations.py
+++ b/tests/functions_tests/test_activations.py
@@ -4,10 +4,10 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 from chainer import testing
-import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -38,7 +38,7 @@ class TestActivations(unittest.TestCase):
 
         ops = getattr(F, self.name)
         self.model = Model(ops)
-        self.x = np.random.randn(1, 5).astype(np.float32)
+        self.x = input_generator.increasing(2, 5)
         self.fn = self.name + '.onnx'
 
     def test_output(self):
@@ -64,7 +64,7 @@ class TestPReLU(unittest.TestCase):
                 return self.prelu(x)
 
         self.model = Model()
-        self.x = np.zeros((1, 5), dtype=np.float32)
+        self.x = input_generator.increasing(2, 5)
         self.fn = 'PReLU.onnx'
 
     def test_output(self):

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -7,6 +7,7 @@ import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -128,7 +129,7 @@ class TestArrayOperators(unittest.TestCase):
                 return self.ops(**self.args)
 
         self.model = Model(self.ops, self.args, self.input_argname)
-        self.x = np.zeros(self.input_shape, dtype=np.float32)
+        self.x = input_generator.increasing(*self.input_shape)
         self.fn = self.ops + '.onnx'
 
     def test_output(self):
@@ -155,8 +156,8 @@ class TestConcat(unittest.TestCase):
                 return F.concat((x1, x2))
 
         self.model = Model()
-        self.x1 = np.zeros((1, 5), dtype=np.float32)
-        self.x2 = np.ones((1, 5), dtype=np.float32)
+        self.x1 = input_generator.increasing(2, 5)
+        self.x2 = input_generator.increasing(2, 4)
         self.fn = 'Concat.onnx'
 
     def test_output(self):

--- a/tests/functions_tests/test_connections.py
+++ b/tests/functions_tests/test_connections.py
@@ -7,6 +7,7 @@ import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -82,7 +83,8 @@ class TestConnections(unittest.TestCase):
             self.x = np.random.randint(0, self.args[0], size=self.in_shape)
             self.x = self.x.astype(self.in_type)
         else:
-            self.x = np.zeros(self.in_shape, dtype=self.in_type)
+            self.x = input_generator.increasing(
+                *self.in_shape, dtype=self.in_type)
         self.fn = self.link.__name__ + '.onnx'
 
     def test_output(self):

--- a/tests/functions_tests/test_maths.py
+++ b/tests/functions_tests/test_maths.py
@@ -2,10 +2,10 @@ import unittest
 
 import chainer
 from chainer import testing
-import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -54,7 +54,7 @@ class TestUnaryMathOperators(unittest.TestCase):
                 return eval(self.ops)
 
         self.model = Model(self.ops)
-        self.a = chainer.Variable(np.ones((2, 3), dtype=np.float32))
+        self.a = chainer.Variable(input_generator.positive_increasing(2, 3))
         self.fn = self.info + '.onnx'
 
     def test_output(self):
@@ -94,8 +94,8 @@ class TestBinaryMathOperators(unittest.TestCase):
                 return eval(self.ops)
 
         self.model = Model(self.ops)
-        a = chainer.Variable(np.ones((2, 3), dtype=np.float32))
-        b = chainer.Variable(np.ones((2, 3), dtype=np.float32) * 2)
+        a = chainer.Variable(input_generator.increasing(2, 3))
+        b = chainer.Variable(input_generator.nonzero_increasing(2, 3) * 0.3)
         self.x = (a, b)
         self.fn = self.info + '.onnx'
 
@@ -130,9 +130,9 @@ class TestTernaryMathOperators(unittest.TestCase):
                 return eval(self.ops)
 
         self.model = Model(self.ops)
-        a = chainer.Variable(np.ones((2, 3), dtype=np.float32))
-        b = chainer.Variable(np.ones((2, 3), dtype=np.float32) * 2)
-        c = chainer.Variable(np.ones((2, 3), dtype=np.float32) * 3)
+        a = chainer.Variable(input_generator.increasing(2, 3))
+        b = chainer.Variable(input_generator.increasing(2, 3) * 0.3)
+        c = chainer.Variable(input_generator.increasing(2, 3) * 0.7)
         self.x = (a, b, c)
         self.fn = self.info + '.onnx'
 

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -4,16 +4,11 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 from chainer import testing
-import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
-
-
-def _arange(*shape):
-    r = np.prod(shape)
-    return np.arange(r).reshape(shape).astype(np.float32)
 
 
 @testing.parameterize(
@@ -48,7 +43,7 @@ class TestNormalizations(unittest.TestCase):
 
         ops = getattr(F, self.name)
         self.model = Model(ops, self.args, self.input_argname)
-        self.x = _arange(1, 5, 3, 3)
+        self.x = input_generator.increasing(2, 5, 3, 3)
         self.fn = self.name + '.onnx'
 
     def test_output(self):
@@ -79,7 +74,7 @@ class TestBatchNormalization(unittest.TestCase):
                 return self.bn(x)
 
         self.model = Model()
-        self.x = _arange(1, 5)
+        self.x = input_generator.increasing(2, 5)
         self.fn = 'BatchNormalization.onnx'
 
     def test_output(self):

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -3,10 +3,10 @@ import unittest
 import chainer
 import chainer.functions as F
 from chainer import testing
-import numpy as np
 import onnx
 
 import onnx_chainer
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -31,7 +31,7 @@ class TestPoolings(unittest.TestCase):
     def setUp(self):
         ops = getattr(F, self.name)
         self.model = Model(ops, self.args, self.cover_all)
-        self.x = np.ones(self.in_shape, dtype=np.float32)
+        self.x = input_generator.increasing(*self.in_shape)
         self.fn = self.name + '.onnx'
 
     def test_output(self):
@@ -53,7 +53,7 @@ class TestPoolingsWithUnsupportedSettings(unittest.TestCase):
     def setUp(self):
         ops = getattr(F, self.name)
         self.model = Model(ops, self.args, self.cover_all)
-        self.x = np.ones(self.in_shape, dtype=np.float32)
+        self.x = input_generator.increasing(*self.in_shape)
         self.fn = self.name + '.onnx'
 
     def test_output(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,10 +1,11 @@
 import unittest
 
+import numpy as np
 import chainer
 import chainer.functions as F
 import chainer.links as L
-import numpy as np
 
+from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime
 
 
@@ -23,9 +24,9 @@ class TestMultipleInputs(unittest.TestCase):
                 return F.relu(x) + self.prelu(y) * z
 
         self.model = Model()
-        self.ins = (np.zeros((1, 5), dtype=np.float32),
-                    np.zeros((1, 5), dtype=np.float32),
-                    np.zeros((1, 5), dtype=np.float32))
+        self.ins = (input_generator.increasing(1, 5),
+                    input_generator.increasing(1, 5),
+                    input_generator.increasing(1, 5))
         self.fn = 'MultiInputs.onnx'
 
     def test_arrays(self):

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,9 +1,9 @@
 import unittest
 
-import numpy as np
 import chainer
 import chainer.functions as F
 import chainer.links as L
+import numpy as np
 
 from onnx_chainer.testing import input_generator
 from onnx_chainer.testing import test_onnxruntime


### PR DESCRIPTION
- All tests use deterministic yet more interesting numbers as
  their inputs. Hopefully these deterministic numbers keep
  tests not flaky but increase the coverage of tests.
- Tests now use numpy's assert_allclose to specify both `rtol`
  and `atol`. We need to be able to specify both relative
  tolerance and absolute torelance since we now have near-zero
  numbers.