### PR TITLE
Use stride!=1 to test cover_all of MaxPool

### DIFF
--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -20,11 +20,11 @@ from onnx_chainer.testing import test_onnxruntime
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
      'in_shape': (1, 3, 6, 6), 'args': [2, 1, 1], 'cover_all': False},
     {'name': 'max_pooling_2d', 'ops': F.max_pooling_2d,
-     'in_shape': (1, 3, 6, 5), 'args': [3, 1, 1], 'cover_all': True},
+     'in_shape': (1, 3, 6, 5), 'args': [3, (2, 1), 1], 'cover_all': True},
     {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
      'in_shape': (1, 3, 6, 6, 6), 'args': [2, 1, 1], 'cover_all': False},
     {'name': 'max_pooling_nd', 'ops': F.max_pooling_nd,
-     'in_shape': (1, 3, 6, 5, 4), 'args': [3, 1, 1], 'cover_all': True},
+     'in_shape': (1, 3, 6, 5, 4), 'args': [3, 2, 1], 'cover_all': True},
 )
 class TestPoolings(unittest.TestCase):
 


### PR DESCRIPTION
Right/bottom padding is calculated by pad + stride - 1. With
original stride values, pads in ONNX will not be different from
the one calculated by the other code path.