### PR TITLE
Fix the random seed at the beginning of tests

### DIFF
--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -24,6 +24,8 @@ TEST_OUT_DIR = 'out'
 
 
 def check_output(model, x, filename, out_key='prob', opset_version=None):
+    model.xp.random.seed(42)
+
     os.makedirs(TEST_OUT_DIR, exist_ok=True)
     filename = os.path.join(TEST_OUT_DIR, filename)
 


### PR DESCRIPTION
It seems this fixes the flakiness of test_convolution.py. It
passed 100 times in a row.