### PR TITLE
Fix graph exporter when model has multiple outputs

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -99,13 +99,10 @@ class ONNXExport(chainer.FunctionHook):
         self.additional_parameters = []
         self.middle_output_var_to_varnode = {}
         self.specified_opset_version = opset_version
-        self._called_funcs = set()
 
     def backward_postprocess(self, function, in_data, out_grad):
         if isinstance(function, chainer.function.FunctionAdapter):
             function = function.function
-        if id(function) in self._called_funcs:
-            return
         func_name = function.__class__.__name__
         input_names = []
         for i in function.inputs:
@@ -144,7 +141,6 @@ class ONNXExport(chainer.FunctionHook):
             func_name, onnx_op_name, opset_version, function, input_names,
             output_names, self.additional_parameters)
         self.graph.extend(nodes)
-        self._called_funcs.add(id(function))
 
 
 def export(model, args, filename=None, export_params=True,

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -69,20 +69,10 @@ def rename_tensors(model):
     names = {v.name: v.name for v in model.graph.initializer}
     op_counts = collections.defaultdict(int)
 
-    # first, collect renamed outputs because mode.graph can not be
-    # topological sorted, means input name can be an output of other node.
     for op in model.graph.node:
         op_name = '{}_{}'.format(op.op_type, op_counts[op.op_type])
         op_counts[op.op_type] += 1
-        for i, out in enumerate(op.output):
-            if len(op.output) <= 1:
-                rename = op_name
-            else:
-                rename = '{}_{}'.format(op_name, i)
-            names[out] = rename
 
-    # second, rename tail and head name of edges directly
-    for op in model.graph.node:
         for i in range(len(op.input)):
             if op.input[i] not in names:
                 names[op.input[i]] = 'Input_{}'.format(op_counts['Input'])
@@ -90,6 +80,10 @@ def rename_tensors(model):
             op.input[i] = names[op.input[i]]
 
         for i in range(len(op.output)):
+            if len(op.output) <= 1:
+                names[op.output[i]] = op_name
+            else:
+                names[op.output[i]] = '{}_{}'.format(op_name, i)
             op.output[i] = names[op.output[i]]
 
     for v in tuple(model.graph.input) + tuple(model.graph.output):

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -99,10 +99,13 @@ class ONNXExport(chainer.FunctionHook):
         self.additional_parameters = []
         self.middle_output_var_to_varnode = {}
         self.specified_opset_version = opset_version
+        self.called_funcs = set()
 
     def backward_postprocess(self, function, in_data, out_grad):
         if isinstance(function, chainer.function.FunctionAdapter):
             function = function.function
+        if str(id(function)) in self.called_funcs:
+            return
         func_name = function.__class__.__name__
         input_names = []
         for i in function.inputs:
@@ -143,6 +146,7 @@ class ONNXExport(chainer.FunctionHook):
         for node in nodes:
             if node not in self.graph:
                 self.graph.append(node)
+        self.called_funcs.add(str(id(function)))
 
 
 def export(model, args, filename=None, export_params=True,

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -255,8 +255,9 @@ def export(model, args, filename=None, export_params=True,
         elif isinstance(outputs, chainer.Variable):
             flat_outputs = [outputs]
         else:
-            raise RuntimeError('Unexpected output type from the model: %s' %
-                               type(outputs))
+            raise RuntimeError(
+                'Unexpected output type from the model: {}'.format(
+                    type(outputs)))
         chainer.grad(flat_outputs, list(model.params()) + flat_args)
 
     implicit_input_names = set(o.inputs.keys()) - param_names -\

--- a/onnx_chainer/testing/test_mxnet.py
+++ b/onnx_chainer/testing/test_mxnet.py
@@ -45,9 +45,9 @@ def check_compatibility(model, x, fn, out_keys=['prob'], opset_version=None):
     if isinstance(chainer_out, (list, tuple)):
         chainer_out = [y.array for y in chainer_out]
     elif isinstance(chainer_out, dict):
-        chainer_out = chainer_out[out_key]
-        if isinstance(chainer_out, chainer.Variable):
-            chainer_out = (chainer_out.array,)
+        chainer_outs = [chainer_out[k] for k in out_keys]
+        chainer_out = tuple(out.array if isinstance(out, chainer.Variable) else
+                            out for out in chainer_outs)
     elif isinstance(chainer_out, chainer.Variable):
         chainer_out = (chainer_out.array,)
     else:

--- a/onnx_chainer/testing/test_mxnet.py
+++ b/onnx_chainer/testing/test_mxnet.py
@@ -19,7 +19,7 @@ except ImportError:
     MXNET_AVAILABLE = False
 
 
-def check_compatibility(model, x, fn, out_keys=['prob'], opset_version=None):
+def check_compatibility(model, x, fn, out_keys=None, opset_version=None):
     if opset_version is None:
         opset_version = onnx.defs.onnx_opset_version()
     if not MXNET_AVAILABLE:

--- a/onnx_chainer/testing/test_mxnet.py
+++ b/onnx_chainer/testing/test_mxnet.py
@@ -19,7 +19,7 @@ except ImportError:
     MXNET_AVAILABLE = False
 
 
-def check_compatibility(model, x, fn, out_key='prob', opset_version=None):
+def check_compatibility(model, x, fn, out_keys=['prob'], opset_version=None):
     if opset_version is None:
         opset_version = onnx.defs.onnx_opset_version()
     if not MXNET_AVAILABLE:

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -23,7 +23,7 @@ MINIMUM_OPSET_VERSION = 7
 TEST_OUT_DIR = 'out'
 
 
-def check_output(model, x, filename, out_keys=['prob'], opset_version=None):
+def check_output(model, x, filename, out_keys=None, opset_version=None):
     model.xp.random.seed(42)
 
     os.makedirs(TEST_OUT_DIR, exist_ok=True)

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -63,13 +63,16 @@ def check_output(model, x, filename, out_keys=['prob'], opset_version=None):
 
     rt_out_keys = None
     if isinstance(chainer_out, (list, tuple)):
-        chainer_out = (y.array for y in chainer_out)
+        chainer_out = tuple(y.array for y in chainer_out)
+        if out_keys is not None:
+            assert len(out_keys) == len(chainer_out)
+            rt_out_keys = out_keys
     elif isinstance(chainer_out, dict):
         if len(out_keys) > 1:
             rt_out_keys = out_keys
         chainer_outs = [chainer_out[k] for k in out_keys]
-        chainer_out = (out.array if isinstance(out, chainer.Variable) else out
-                       for out in chainer_outs)
+        chainer_out = tuple(out.array if isinstance(out, chainer.Variable) else
+                            out for out in chainer_outs)
     elif isinstance(chainer_out, chainer.Variable):
         chainer_out = (chainer_out.array,)
     else:

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -23,7 +23,7 @@ MINIMUM_OPSET_VERSION = 7
 TEST_OUT_DIR = 'out'
 
 
-def check_output(model, x, filename, out_key='prob', opset_version=None):
+def check_output(model, x, filename, out_keys=['prob'], opset_version=None):
     model.xp.random.seed(42)
 
     os.makedirs(TEST_OUT_DIR, exist_ok=True)
@@ -61,15 +61,13 @@ def check_output(model, x, filename, out_key='prob', opset_version=None):
             ' chainer.Variable itself. But a {} object was given.'.format(
                 type(x)))
 
-    rt_out_key = None
+    rt_out_keys = None
     if isinstance(chainer_out, (list, tuple)):
         chainer_out = (y.array for y in chainer_out)
     elif isinstance(chainer_out, dict):
-        if isinstance(out_key, str):
-            out_key = [out_key]
-        if len(out_key) > 1:
-            rt_out_key = out_key
-        chainer_outs = [chainer_out[k] for k in out_key]
+        if len(out_keys) > 1:
+            rt_out_keys = out_keys
+        chainer_outs = [chainer_out[k] for k in out_keys]
         chainer_out = (out.array if isinstance(out, chainer.Variable) else out
                        for out in chainer_outs)
     elif isinstance(chainer_out, chainer.Variable):
@@ -98,7 +96,7 @@ def check_output(model, x, filename, out_key='prob', opset_version=None):
     assert list(sorted(input_names)) == list(sorted(graph_input_names))
 
     rt_out = sess.run(
-        rt_out_key, {name: array for name, array in zip(input_names, x_rt)})
+        rt_out_keys, {name: array for name, array in zip(input_names, x_rt)})
 
     for cy, my in zip(chainer_out, rt_out):
         np.testing.assert_allclose(cy, my, rtol=1e-5, atol=1e-5)

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -104,4 +104,4 @@ class TestMultipleOutput(unittest.TestCase):
         model = self.get_model(use_bn=self.use_bn)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
         test_onnxruntime.check_output(
-            model, x, 'MultipleOutputs.onnx', out_key=['Tanh_0', 'Sigmoid_0'])
+            model, x, 'MultipleOutputs.onnx', out_keys=['Tanh_0', 'Sigmoid_0'])

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -3,7 +3,6 @@ import unittest
 import chainer
 import chainer.functions as F
 import chainer.links as L
-from chainer import testing
 import numpy as np
 
 from onnx_chainer.testing import input_generator
@@ -83,7 +82,7 @@ class TestMultipleOutput(unittest.TestCase):
                 with self.init_scope():
                     self.conv = L.Convolution2D(None, 32, ksize=3, stride=1)
                     if self._use_bn:
-                        self.bn = L.BatchNormalization(32, use_beta=False)
+                        self.bn = L.BatchNormalization(32)
 
             def __call__(self, x):
                 h = self.conv(x)
@@ -99,4 +98,6 @@ class TestMultipleOutput(unittest.TestCase):
     def test_multiple_outputs(self):
         model = self.get_model(use_bn=True)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
-        test_onnxruntime.check_output(model, x, 'multiple_outputs.onnx', 'out1')
+        # TODO(disktnk) fix check_output to accept several output keys.
+        test_onnxruntime.check_output(
+            model, x, 'multiple_outputs.onnx', 'out1')

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -72,18 +72,21 @@ class TestImplicitInput(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'use_bn': True},
-    {'use_bn': False},
+    {'use_bn': True, 'out_type': 'dict'},
+    {'use_bn': False, 'out_type': 'dict'},
+    {'use_bn': True, 'out_type': 'tuple'},
+    {'use_bn': True, 'out_type': 'list'},
 )
 class TestMultipleOutput(unittest.TestCase):
 
-    def get_model(self, use_bn=False):
+    def get_model(self, use_bn=False, out_type=None):
         class Model(chainer.Chain):
 
-            def __init__(self, use_bn=False):
+            def __init__(self, use_bn=False, out_type=None):
                 super(Model, self).__init__()
 
                 self._use_bn = use_bn
+                self._out_type = out_type
                 with self.init_scope():
                     self.conv = L.Convolution2D(None, 32, ksize=3, stride=1)
                     if self._use_bn:
@@ -93,15 +96,25 @@ class TestMultipleOutput(unittest.TestCase):
                 h = self.conv(x)
                 if self._use_bn:
                     h = self.bn(h)
-                return {
-                    'Tanh_0': F.tanh(h),
-                    'Sigmoid_0': F.sigmoid(h)
-                }
+                o1 = F.tanh(h)
+                o2 = F.sigmoid(h)
+                if self._out_type == 'dict':
+                    return {
+                        'Tanh_0': o1,
+                        'Sigmoid_0': o2
+                    }
+                elif self._out_type == 'tuple':
+                    return o1, o2
+                elif self._out_type == 'list':
+                    return [o1, o2]
 
-        return Model(use_bn=use_bn)
+        return Model(use_bn=use_bn, out_type=out_type)
 
     def test_multiple_outputs(self):
-        model = self.get_model(use_bn=self.use_bn)
+        model = self.get_model(use_bn=self.use_bn, out_type=self.out_type)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
+        # 'out_keys' is necessary even if self.out_type is tuple or list
+        # because onnxruntime does not guarantee the order of outputs when
+        # output keys are None.
         test_onnxruntime.check_output(
             model, x, 'MultipleOutputs.onnx', out_keys=['Tanh_0', 'Sigmoid_0'])

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -3,6 +3,7 @@ import unittest
 import chainer
 import chainer.functions as F
 import chainer.links as L
+from chainer import testing
 import numpy as np
 
 from onnx_chainer.testing import input_generator
@@ -70,6 +71,10 @@ class TestImplicitInput(unittest.TestCase):
         test_onnxruntime.check_output(self.model, x, self.fn)
 
 
+@testing.parameterize(
+    {'use_bn': True},
+    {'use_bn': False},
+)
 class TestMultipleOutput(unittest.TestCase):
 
     def get_model(self, use_bn=False):
@@ -96,7 +101,7 @@ class TestMultipleOutput(unittest.TestCase):
         return Model(use_bn=use_bn)
 
     def test_multiple_outputs(self):
-        model = self.get_model(use_bn=True)
+        model = self.get_model(use_bn=self.use_bn)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
         test_onnxruntime.check_output(
-            model, x, 'multiple_outputs.onnx', out_key=['Tanh_0', 'Sigmoid_0'])
+            model, x, 'MultipleOutputs.onnx', out_key=['Tanh_0', 'Sigmoid_0'])

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -89,8 +89,8 @@ class TestMultipleOutput(unittest.TestCase):
                 if self._use_bn:
                     h = self.bn(h)
                 return {
-                    'out1': F.sigmoid(h),
-                    'out2': F.sigmoid(h)
+                    'Tanh_0': F.tanh(h),
+                    'Sigmoid_0': F.sigmoid(h)
                 }
 
         return Model(use_bn=use_bn)
@@ -98,6 +98,5 @@ class TestMultipleOutput(unittest.TestCase):
     def test_multiple_outputs(self):
         model = self.get_model(use_bn=True)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
-        # TODO(disktnk) fix check_output to accept several output keys.
         test_onnxruntime.check_output(
-            model, x, 'multiple_outputs.onnx', 'out1')
+            model, x, 'multiple_outputs.onnx', out_key=['Tanh_0', 'Sigmoid_0'])


### PR DESCRIPTION
fixes #99 

- [x] prevent to generate duplicated nodes
- in rename tensors, deal with model graph which is **not** topologically sorted
  - [x] before rename, model graph fix to sort topologically
- [x] in output check test, accept multiple keys when outputs are `dict` type