### PR TITLE
Export testcase

### DIFF
--- a/onnx_chainer/__init__.py
+++ b/onnx_chainer/__init__.py
@@ -5,5 +5,7 @@ from onnx_chainer.export import export  # NOQA
 
 from onnx_chainer.export import MINIMUM_OPSET_VERSION  # NOQA
 
+from onnx_chainer.export_testcase import export_testcase  # NOQA
+
 
 __version__ = pkg_resources.get_distribution('onnx-chainer').version

--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -25,10 +25,10 @@ def export_testcase(model, args, out_dir, graph_name='Graph'):
     """
     os.makedirs(out_dir, exist_ok=True)
     export(model, args,
-           filename='%s/model.onnx' % out_dir,
+           filename=os.path.join(out_dir, 'model.onnx'),
            graph_name=graph_name)
 
-    test_data_dir = '%s/test_data_set_0' % out_dir
+    test_data_dir = os.path.join(out_dir, 'test_data_set_0')
     os.makedirs(test_data_dir, exist_ok=True)
     for i, var in enumerate(list(args)):
         with open(os.path.join(test_data_dir, 'input_%d.pb' % i), 'wb') as f:

--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -1,7 +1,6 @@
 import chainer
 import os
 
-import numpy as np
 from onnx import numpy_helper
 
 
@@ -39,11 +38,7 @@ def export_testcase(model, args, out_dir):
     chainer.config.train = True
     model.cleargrads()
     result = model(*args)
-    result.grad = np.ones(result.shape, result.dtype)
-    result.backward()
 
-    outputs = [('', result.array)]
-    for i, (name, value) in enumerate(outputs):
-        with open(os.path.join(test_data_dir, 'output_%d.pb' % i), 'wb') as f:
-            t = numpy_helper.from_array(value, name)
-            f.write(t.SerializeToString())
+    with open(os.path.join(test_data_dir, 'output_0.pb'), 'wb') as f:
+        t = numpy_helper.from_array(result.array, '')
+        f.write(t.SerializeToString())

--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -2,41 +2,40 @@ import chainer
 import os
 
 from onnx import numpy_helper
+from onnx_chainer.export import export
 
 
-def makedirs(d):
-    if not os.path.exists(d):
-        os.makedirs(d)
-
-
-def export_testcase(model, args, out_dir):
-    """Export input and output of a model in protobuf format.
+def export_testcase(model, args, out_dir, graph_name='Graph'):
+    """Export model and I/O tensors of the model in protobuf format.
 
     Similar to the `export` function, this function first performs a forward
     computation to a given input for obtaining an output. Then, this function
     saves the pair of input and output in Protobuf format, which is a
     defacto-standard format in ONNX.
 
+    This function also saves the model with the name "model.onnx".
+
     Args:
         model (~chainer.Chain): The model object.
         args (list): The arguments which are given to the model
             directly. Unlike `export` function, only `list` type is accepted.
         out_dir (str): The directory name used for saving the input and output.
+        graph_name (str): A string to be used for the ``name`` field of the
+            graph in the exported ONNX model.
     """
-    makedirs(out_dir)
-    onnx_extra_inputs = []
-    if hasattr(model, 'extra_inputs'):
-        onnx_extra_inputs = model.extra_inputs
+    os.makedirs(out_dir, exist_ok=True)
+    export(model, args,
+           filename='%s/model.onnx' % out_dir,
+           graph_name=graph_name)
 
     test_data_dir = '%s/test_data_set_0' % out_dir
-    makedirs(test_data_dir)
-    for i, var in enumerate(list(args) + list(onnx_extra_inputs)):
+    os.makedirs(test_data_dir, exist_ok=True)
+    for i, var in enumerate(list(args)):
         with open(os.path.join(test_data_dir, 'input_%d.pb' % i), 'wb') as f:
             t = numpy_helper.from_array(var.data, 'Input_%d' % i)
             f.write(t.SerializeToString())
 
     chainer.config.train = True
-    model.cleargrads()
     result = model(*args)
 
     with open(os.path.join(test_data_dir, 'output_0.pb'), 'wb') as f:

--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -1,0 +1,49 @@
+import chainer
+import os
+
+import numpy as np
+from onnx import numpy_helper
+
+
+def makedirs(d):
+    if not os.path.exists(d):
+        os.makedirs(d)
+
+
+def export_testcase(model, args, out_dir):
+    """Export input and output of a model in protobuf format.
+
+    Similar to the `export` function, this function first performs a forward
+    computation to a given input for obtaining an output. Then, this function
+    saves the pair of input and output in Protobuf format, which is a
+    defacto-standard format in ONNX.
+
+    Args:
+        model (~chainer.Chain): The model object.
+        args (list): The arguments which are given to the model
+            directly. Unlike `export` function, only `list` type is accepted.
+        out_dir (str): The directory name used for saving the input and output.
+    """
+    makedirs(out_dir)
+    onnx_extra_inputs = []
+    if hasattr(model, 'extra_inputs'):
+        onnx_extra_inputs = model.extra_inputs
+
+    test_data_dir = '%s/test_data_set_0' % out_dir
+    makedirs(test_data_dir)
+    for i, var in enumerate(list(args) + list(onnx_extra_inputs)):
+        with open(os.path.join(test_data_dir, 'input_%d.pb' % i), 'wb') as f:
+            t = numpy_helper.from_array(var.data, 'Input_%d' % i)
+            f.write(t.SerializeToString())
+
+    chainer.config.train = True
+    model.cleargrads()
+    result = model(*args)
+    result.grad = np.ones(result.shape, result.dtype)
+    result.backward()
+
+    outputs = [('', result.array)]
+    for i, (name, value) in enumerate(outputs):
+        with open(os.path.join(test_data_dir, 'output_%d.pb' % i), 'wb') as f:
+            t = numpy_helper.from_array(value, name)
+            f.write(t.SerializeToString())


### PR DESCRIPTION
I ported the implementation of test case export in `chainer_compiler` https://github.com/pfnet-research/chainer-compiler/blob/master/scripts/onnx_chainer_util.py.
Some functionalities such as outputting gradients and replacing ID are omitted.

Question?:
* Should I run the inference with `chainer.config.train=True`? This might be incompatible with the `export` function.
* Can I assume that the number of the outputs of model is always one?