### PR TITLE
Stop emitting batch_size for Linear with no bias

### DIFF
--- a/onnx_chainer/functions/connection.py
+++ b/onnx_chainer/functions/connection.py
@@ -100,9 +100,8 @@ def convert_LinearFunction(func, opset_version, input_names,
                            num_outputs, parameters):
     # When the func has bias
     if len(func.inputs) == 2:
-        batchsize = func.inputs[0].shape[0]
         bias_dim = func.inputs[1].shape[0]
-        bias = np.zeros((batchsize, bias_dim), dtype=np.float32)
+        bias = np.zeros((bias_dim,), dtype=np.float32)
         bias_param = chainer.Parameter(bias)
         parameters.append(bias_param)
         input_names.append(str(id(bias_param)))


### PR DESCRIPTION
Though the original code would be conformant to the ONNX
standard, it would be better not to have batch_size in zero
bias for Gemm because

- users may be able to change batch_size after ONNX generation
- generated ONNX will be slightly smaller

https://github.com/chainer/onnx-chainer/issues/103