### PR TITLE
Add a check for opset version

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -142,6 +142,11 @@ class ONNXExport(chainer.FunctionHook):
                 if opset_version <= self.specified_opset_version:
                     break
 
+        if opset_version > self.specified_opset_version:
+            raise RuntimeError('ONNX-chainer cannot convert `{}` of Chainer '
+                               'with ONNX opset_version {}'.format(
+                                   func_name, self.specified_opset_version))
+
         nodes = create_node(
             func_name, opset_version, function, input_names,
             output_names, self.additional_parameters)


### PR DESCRIPTION
PR #110 is adding a mapping whose minimal supported opset
version is not 1. Improve the error message when no ONNX op
is available for the specified opset version.