### PR TITLE
Fix MulConstant value as scalar

### DIFF
--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -47,7 +47,7 @@ def convert_Mul(func, opset_version, input_names, num_outputs,
 
 def convert_MulConstant(func, opset_version, input_names,
                         num_outputs, parameters):
-    value = np.asarray([func.value], dtype=func.inputs[0].dtype)
+    value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(str(id(value_param)))


### PR DESCRIPTION
Remove unnecessary operation to set value, When called `MulConstant`, `func.value` must be a scalar ref https://github.com/chainer/chainer/blob/master/chainer/functions/math/basic_math.py#L390