### PR TITLE
Fix BatchNormalization test

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -215,6 +215,7 @@ def export(model, args, filename=None, export_params=True,
         chainer.config.train = True
     else:
         chainer.config.train = False
+    chainer.config.in_recomputing = False
     chainer.config.enable_backprop = True
 
     if opset_version is None:

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -98,19 +98,6 @@ def rename_tensors(model):
             v.name = names[v.name]
 
 
-@contextlib.contextmanager
-def set_temporary_chainer_config(**kwargs):
-    org_config = chainer.config
-    temp_conf = chainer.configuration.LocalConfig(chainer.config)
-    for k, v in kwargs.items():
-        setattr(temp_conf, k, v)
-    try:
-        chainer.config = temp_conf
-        yield
-    finally:
-        chainer.config = org_config
-
-
 class ONNXExport(chainer.FunctionHook):
 
     def __init__(self, context, opset_version=None):
@@ -228,12 +215,9 @@ def export(model, args, filename=None, export_params=True,
 
     _check_available()
 
-    chainer_config = {
-        'train': train,
-        'in_recomputing': True,
-        'enable_backprop': True,
-    }
-    with set_temporary_chainer_config(**chainer_config):
+    with chainer.using_config('train', train),\
+            chainer.using_config('in_recomputing', True),\
+            chainer.using_config('enable_backprop', True):
         return _export(
             model, args, filename, export_params, graph_name, save_text,
             opset_version, return_flat_inout)

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -167,7 +167,7 @@ class ONNXExport(chainer.FunctionHook):
 
 def export(model, args, filename=None, export_params=True,
            graph_name='Graph', save_text=False, opset_version=None,
-           return_flat_inout=False):
+           train=False, return_flat_inout=False):
     """Export function for chainer.Chain in ONNX format.
 
     This function performs a forward computation of the given
@@ -197,6 +197,7 @@ def export(model, args, filename=None, export_params=True,
             or ``None`` is given, the latest opset version of the onnx module
             is used. If an integer is given, it will be ensured that all the
             operator version in the exported ONNX file is less than this value.
+        train (bool): If True, output computational graph with train mode.
         return_flat_inout (bool): If set True, return ONNX model with flat
             inputs, and flat outputs.
 
@@ -210,7 +211,10 @@ def export(model, args, filename=None, export_params=True,
 
     _check_available()
 
-    chainer.config.train = False
+    if train:
+        chainer.config.train = True
+    else:
+        chainer.config.train = False
     chainer.config.enable_backprop = True
 
     if opset_version is None:

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import collections
-import contextlib
 import warnings
 
 import chainer

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -104,9 +104,11 @@ def set_temporary_chainer_config(**kwargs):
     temp_conf = chainer.configuration.LocalConfig(chainer.config)
     for k, v in kwargs.items():
         setattr(temp_conf, k, v)
-    chainer.config = temp_conf
-    yield
-    chainer.config = org_config
+    try:
+        chainer.config = temp_conf
+        yield
+    finally:
+        chainer.config = org_config
 
 
 class ONNXExport(chainer.FunctionHook):

--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -9,7 +9,7 @@ from onnx_chainer.export import export
 
 def export_testcase(
         model, args, out_dir, graph_name='Graph', output_grad=False,
-        opset_version=None):
+        opset_version=None, train=False):
     """Export model and I/O tensors of the model in protobuf format.
 
     Similar to the `export` function, this function first performs a forward
@@ -26,15 +26,16 @@ def export_testcase(
         out_dir (str): The directory name used for saving the input and output.
         graph_name (str): A string to be used for the ``name`` field of the
             graph in the exported ONNX model.
-        output_grad (boolean): If True, this function will output model's
+        output_grad (bool): If True, this function will output model's
             gradient with names 'gradient_%d.pb'.
+        train (bool): If True, output computational graph with train mode.
     """
     os.makedirs(out_dir, exist_ok=True)
     model.cleargrads()
     _, inputs, outputs = export(
         model, args, filename=os.path.join(out_dir, 'model.onnx'),
         graph_name=graph_name, opset_version=opset_version,
-        return_flat_inout=True)
+        train=train, return_flat_inout=True)
 
     test_data_dir = os.path.join(out_dir, 'test_data_set_0')
     os.makedirs(test_data_dir, exist_ok=True)

--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -7,17 +7,23 @@ from onnx_chainer import onnx_helper
 
 def convert_BatchNormalization(func, opset_version, input_names,
                                num_outputs, context, parameters):
-    x = func.inputs[0].get_variable().data
-    mean = chainer.Parameter(x.mean(axis=func.axis))
+    if len(func.inputs) <= 3:
+        # expect this `func` is F.batch_normalization
+        x = func.inputs[0].get_variable().array
+        mean = chainer.Parameter(x.mean(axis=func.axis))
+        input_names.append(context.get_name(mean))
+        var = chainer.Parameter(x.var(axis=func.axis))
+        input_names.append(context.get_name(var))
+    else:
+        # expect this `func` is F.fixed_batch_normalization
+        mean = chainer.Parameter(func.inputs[3].get_variable().array)
+        input_names[3] = context.get_name(mean)
+        var = chainer.Parameter(func.inputs[4].get_variable().array)
+        input_names[4] = context.get_name(var)
     parameters.append(mean)
-    input_names.append(context.get_name(mean))
-    var = chainer.Parameter(x.var(axis=func.axis))
     parameters.append(var)
-    input_names.append(context.get_name(var))
 
-    # TODO(disktnk): ONNX's BatchNormalization operator outputs one required
-    # output and four optional outputs. This converter must make 5 values for
-    # output and return them.
+    momentum = getattr(func, 'decay', 0.)
 
     # if `use_beta=False`, passed None value to the functions
     if func.inputs[2].get_variable_or_none() is None:
@@ -30,11 +36,15 @@ def convert_BatchNormalization(func, opset_version, input_names,
         parameters.append(gamma)
         input_names[1] = context.get_name(gamma)
 
+    # TODO(disktnk): On definition of ONNX's BatchNormalization operator,
+    # outputs one required output and four optional outputs. This converter
+    # must make 5 values for output and return them.
+
     if opset_version == 1:
         return onnx_helper.make_node(
             'BatchNormalization', input_names, num_outputs,
             epsilon=func.eps,
-            momentum=func.decay,
+            momentum=momentum,
             is_test=not chainer.config.train,
             consumed_inputs=[False, False, False, True, True],
         ),
@@ -42,63 +52,22 @@ def convert_BatchNormalization(func, opset_version, input_names,
         return onnx_helper.make_node(
             'BatchNormalization', input_names, num_outputs,
             epsilon=func.eps,
-            momentum=func.decay,
+            momentum=momentum,
             is_test=not chainer.config.train,
         ),
     elif opset_version == 7:
         return onnx_helper.make_node(
             'BatchNormalization', input_names, num_outputs,
             epsilon=func.eps,
-            momentum=func.decay,
+            momentum=momentum,
         ),
 
 
 def convert_FixedBatchNormalization(func, opset_version,
                                     input_names, num_outputs, context,
                                     parameters):
-    # Add avg_mean and avg_var to graph
-    mean_arr, var_arr = [i.get_variable().array for i in func.inputs[3:]]
-
-    mean_arr_param = chainer.Parameter(mean_arr)
-    parameters.append(mean_arr_param)
-    input_names[3] = context.get_name(mean_arr_param)
-
-    var_arr_param = chainer.Parameter(var_arr)
-    parameters.append(var_arr_param)
-    input_names[4] = context.get_name(var_arr_param)
-
-    # if `use_beta=False`, passed None value to the functions
-    if func.inputs[2].get_variable_or_none() is None:
-        beta = chainer.Parameter(np.zeros_like(mean_arr, dtype=mean_arr.dtype))
-        parameters.append(beta)
-        input_names[2] = context.get_name(beta)
-    # `use_gamma=False` is same
-    if func.inputs[1].get_variable_or_none() is None:
-        gamma = chainer.Parameter(np.ones_like(mean_arr, dtype=mean_arr.dtype))
-        parameters.append(gamma)
-        input_names[1] = context.get_name(gamma)
-
-    if opset_version == 1:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
-            epsilon=func.eps,
-            momentum=0.,
-            is_test=not chainer.config.train,
-            consumed_inputs=[False, False, False, True, True],
-        ),
-    elif opset_version == 6:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
-            epsilon=func.eps,
-            momentum=0.,
-            is_test=not chainer.config.train,
-        ),
-    elif opset_version == 7:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
-            epsilon=func.eps,
-            momentum=0.,
-        ),
+    return convert_BatchNormalization(
+        func, opset_version, input_names, num_outputs, context, parameters)
 
 
 def convert_LocalResponseNormalization(func, opset_version,

--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -15,13 +15,9 @@ def convert_BatchNormalization(func, opset_version, input_names,
     parameters.append(var)
     input_names.append(str(id(var)))
 
-    # unique_layer_name = '{}_{}'.format(func.__class__.__name__, str(id(func)))
-    # num_outputs += [
-    #     unique_layer_name + '_mean',
-    #     unique_layer_name + '_var',
-    #     unique_layer_name + '_saved_mean',
-    #     unique_layer_name + '_saved_var'
-    # ]
+    # TODO(disktnk): ONNX's BatchNormalization operator outputs one required
+    # output and four optional outputs. This converter must make 5 values for
+    # output and return them.
 
     # if `use_beta=False`, passed None value to the functions
     if func.inputs[2].get_variable_or_none() is None:

--- a/onnx_chainer/testing/get_test_data_set.py
+++ b/onnx_chainer/testing/get_test_data_set.py
@@ -4,10 +4,11 @@ import onnx_chainer
 from onnx_chainer.testing.test_onnxruntime import TEST_OUT_DIR
 
 
-def gen_test_data_set(model, args, name, opset_version):
+def gen_test_data_set(model, args, name, opset_version, train):
     model.xp.random.seed(42)
     test_path = os.path.join(
         TEST_OUT_DIR, 'opset{}'.format(opset_version), name)
     onnx_chainer.export_testcase(
-        model, args, test_path, opset_version=opset_version)
+        model, args, test_path, opset_version=opset_version,
+        train=train)
     return test_path

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -54,6 +54,8 @@ class TestNormalizations(ONNXModelTest):
      'kwargs': {'use_beta': False}, 'condition': 'use_beta_false'},
     {'train': True,
      'kwargs': {'use_gamma': False}, 'condition': 'use_gamma_false'},
+    {'train': True,
+     'kwargs': {'initial_avg_mean': 0.5}, 'condition': 'init_avg_mean'},
 )
 class TestBatchNormalization(ONNXModelTest):
 

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -75,9 +75,7 @@ class TestBatchNormalization(ONNXModelTest):
         self.x = input_generator.increasing(2, 5)
 
     def test_output(self):
-        train = False
-        if hasattr(self, 'train'):
-            train = self.train
+        train = getattr(self, 'train', False)
         name = 'batch_normalization'
         if not train:
             name = 'fixed_' + name

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -49,7 +49,11 @@ class TestNormalizations(ONNXModelTest):
     {'kwargs': {}},
     {'kwargs': {'use_beta': False}, 'condition': 'use_beta_false'},
     {'kwargs': {'use_gamma': False}, 'condition': 'use_gamma_false'},
-    {'kwargs': {}, 'train': True},
+    {'train': True, 'kwargs': {}},
+    {'train': True,
+     'kwargs': {'use_beta': False}, 'condition': 'use_beta_false'},
+    {'train': True,
+     'kwargs': {'use_gamma': False}, 'condition': 'use_gamma_false'},
 )
 class TestBatchNormalization(ONNXModelTest):
 

--- a/tests/functions_tests/test_normalizations.py
+++ b/tests/functions_tests/test_normalizations.py
@@ -47,8 +47,9 @@ class TestNormalizations(ONNXModelTest):
 
 @testing.parameterize(
     {'kwargs': {}},
-    {'kwargs': {'use_beta': False}, 'name': 'use_beta_false'},
-    {'kwargs': {'use_gamma': False}, 'name': 'use_gamma_false'},
+    {'kwargs': {'use_beta': False}, 'condition': 'use_beta_false'},
+    {'kwargs': {'use_gamma': False}, 'condition': 'use_gamma_false'},
+    {'kwargs': {}, 'train': True},
 )
 class TestBatchNormalization(ONNXModelTest):
 
@@ -68,7 +69,12 @@ class TestBatchNormalization(ONNXModelTest):
         self.x = input_generator.increasing(2, 5)
 
     def test_output(self):
-        name = 'batchnormalization'
-        if hasattr(self, 'name'):
-            name += '_' + self.name
-        self.expect(self.model, self.x, name=name)
+        train = False
+        if hasattr(self, 'train'):
+            train = self.train
+        name = 'batch_normalization'
+        if not train:
+            name = 'fixed_' + name
+        if hasattr(self, 'condition'):
+            name += '_' + self.condition
+        self.expect(self.model, self.x, name=name, train=train)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -17,7 +17,7 @@ class ONNXModelTest(unittest.TestCase):
         self.default_name = cls_name[len('Test'):].lower()
 
     def expect(self, model, args, name=None, op_name=None,
-               skip_opset_version=None, with_warning=False):
+               skip_opset_version=None, with_warning=False, train=False):
         """Compare model output and test runtime output.
 
         Make an ONNX model from target model with args, and put output
@@ -30,6 +30,7 @@ class ONNXModelTest(unittest.TestCase):
             op_name (str): name of operator. use for getting opset verseion.
             skip_opset_version (list): versions to skip test.
             with_warning (bool): if True, check warnings.
+            train (bool): If True, output computational graph with train mode.
         """
 
         minimum_version = onnx_chainer.MINIMUM_OPSET_VERSION
@@ -50,10 +51,10 @@ class ONNXModelTest(unittest.TestCase):
             if with_warning:
                 with warnings.catch_warnings(record=True) as w:
                     test_path = gen_test_data_set(
-                        model, args, dir_name, opset_version)
+                        model, args, dir_name, opset_version, train)
                 assert len(w) == 1
             else:
                 test_path = gen_test_data_set(
-                    model, args, dir_name, opset_version)
+                    model, args, dir_name, opset_version, train)
 
             check_model_expect(test_path)

--- a/tests/test_export_testcase.py
+++ b/tests/test_export_testcase.py
@@ -41,7 +41,7 @@ class TestExportTestCase(unittest.TestCase):
     def test_output_grad(self):
         path = 'out/test_export_testcase_with_grad'
         onnx_chainer.export_testcase(
-            self.model, (self.x,), path, output_grad=True)
+            self.model, (self.x,), path, output_grad=True, train=True)
 
         assert os.path.isfile(os.path.join(path, 'model.onnx'))
         assert os.path.isfile(os.path.join(path, 'test_data_set_0',


### PR DESCRIPTION
- support train mode on exporting
- add train mode test on BatchNormalization
- add train mode test on grad output

TODO

- ~change `chainer.config` only when exporting, revert to previous config after exporting~ done
- support optional output on BatchNormalization op --> to be supported