### PR TITLE
Resolve asscalar warning

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -74,7 +74,7 @@ def convert_GetItem(func, opset_version, input_names,
             ends.append(idx+1)
             squeeze_idxs.append(axis)
         elif isinstance(idx, np.ndarray) and idx.ndim == 0:
-            scalar_idx = np.asscalar(idx)
+            scalar_idx = idx.item()
             axes.append(axis)
             starts.append(scalar_idx)
             ends.append(scalar_idx+1)


### PR DESCRIPTION
`numpy.asscalar` is deprecated from v1.16, and replaced it

```
tests/functions_tests/test_arrays.py::TestArrayOperators_param_18_{ops='get_item', input_shape=(2, 2, 3), input_argname='x', args={'slices': array(0)}, name='get_item_npscalar0'}::test_output
tests/functions_tests/test_arrays.py::TestArrayOperators_param_18_{ops='get_item', input_shape=(2, 2, 3), input_argname='x', args={'slices': array(0)}, name='get_item_npscalar0'}::test_output
  /mnt/c/Development/gopath/src/github.com/chainer/onnx-chainer/venv/py36/lib/python3.6/site-packages/numpy/lib/type_check.py:546: DeprecationWarning: np.asscalar(a) is deprecated since NumPy v1.16, use a.item() instead
    'a.item() instead', DeprecationWarning, stacklevel=1)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```