### PR TITLE
Adapt defact-test-output style to complicate test

### DIFF
--- a/onnx_chainer/export_testcase.py
+++ b/onnx_chainer/export_testcase.py
@@ -1,9 +1,9 @@
 import os
 
 import chainer
-from onnx import numpy_helper
 
 from onnx_chainer.export import export
+from onnx_chainer.onnx_helper import write_tensor_pb
 
 
 def export_testcase(
@@ -31,35 +31,42 @@ def export_testcase(
     """
     os.makedirs(out_dir, exist_ok=True)
     model.cleargrads()
-    _, inputs, outputs = export(
+    onnx_model, inputs, outputs = export(
         model, args, filename=os.path.join(out_dir, 'model.onnx'),
         graph_name=graph_name, opset_version=opset_version,
         train=train, return_flat_inout=True)
 
     test_data_dir = os.path.join(out_dir, 'test_data_set_0')
     os.makedirs(test_data_dir, exist_ok=True)
+    # TODO(disktnk): consider to resolve input names smarter
+    input_names = _get_graph_input_names(onnx_model)
     for i, var in enumerate(inputs):
-        with open(os.path.join(test_data_dir, 'input_%d.pb' % i), 'wb') as f:
-            array = chainer.cuda.to_cpu(var.array)
-            t = numpy_helper.from_array(array, 'Input_%d' % i)
-            f.write(t.SerializeToString())
+        pb_name = os.path.join(test_data_dir, 'input_{}.pb'.format(i))
+        array = chainer.cuda.to_cpu(var.array)
+        write_tensor_pb(pb_name, input_names[i], array)
 
     for i, var in enumerate(outputs):
-        with open(os.path.join(test_data_dir, 'output_%d.pb' % i), 'wb') as f:
-            array = chainer.cuda.to_cpu(var.array)
-            t = numpy_helper.from_array(array, '')
-            f.write(t.SerializeToString())
+        pb_name = os.path.join(test_data_dir, 'output_{}.pb'.format(i))
+        array = chainer.cuda.to_cpu(var.array)
+        # TODO(disktnk): set customized output name
+        write_tensor_pb(pb_name, '', array)
 
     if output_grad:
         # Perform backward computation
         if len(outputs) > 1:
             outputs = chainer.functions.identity(*outputs)
         for out in outputs:
-            out.grad = model.xp.ones_like(out.data)
+            out.grad = model.xp.ones_like(out.array)
         outputs[0].backward()
 
         for i, (name, param) in enumerate(model.namedparams()):
-            path = os.path.join(test_data_dir, 'gradient_%d.pb' % i)
-            with open(path, 'wb') as f:
-                t = numpy_helper.from_array(param.grad, name)
-                f.write(t.SerializeToString())
+            pb_name = os.path.join(test_data_dir, 'gradient_{}.pb'.format(i))
+            grad = chainer.cuda.to_cpu(param.grad)
+            write_tensor_pb(pb_name, '', grad)
+
+
+def _get_graph_input_names(onnx_model):
+    initialized_graph_input_names = {
+        i.name for i in onnx_model.graph.initializer}
+    return [i.name for i in onnx_model.graph.input if i.name not in
+            initialized_graph_input_names]

--- a/onnx_chainer/onnx_helper.py
+++ b/onnx_chainer/onnx_helper.py
@@ -96,3 +96,9 @@ class GraphBuilder(object):
           value of converter functions.
         """
         return tuple(self._nodes)
+
+
+def write_tensor_pb(filename, name, value):
+    with open(filename, 'wb') as f:
+        t = onnx.numpy_helper.from_array(value, name)
+        f.write(t.SerializeToString())

--- a/onnx_chainer/testing/get_test_data_set.py
+++ b/onnx_chainer/testing/get_test_data_set.py
@@ -1,7 +1,9 @@
 import os
 
 import onnx_chainer
-from onnx_chainer.testing.test_onnxruntime import TEST_OUT_DIR
+
+
+TEST_OUT_DIR = 'out'
 
 
 def gen_test_data_set(model, args, name, opset_version, train):

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -1,11 +1,8 @@
 import os
 import warnings
 
-import chainer
 import numpy as np
 import onnx
-
-import onnx_chainer
 
 try:
     import onnxruntime as rt
@@ -54,10 +51,6 @@ def check_model_expect(test_path, input_names=None):
         sess = rt.InferenceSession(onnx_model.SerializeToString())
 
         # To detect unexpected inputs created by exporter, check input names
-        # TODO(disktnk): `input_names` got from onnxruntime session includes
-        # only network inputs, does not include internal inputs such as weight
-        # attribute etc. so that need to collect network inputs from
-        # `onnx_model`.
         rt_input_names = [i.name for i in sess.get_inputs()]
         if input_names is not None:
             assert list(sorted(input_names)) == list(sorted(rt_input_names))
@@ -66,101 +59,3 @@ def check_model_expect(test_path, input_names=None):
             None, {name: array for name, array in zip(rt_input_names, inputs)})
         for cy, my in zip(outputs, rt_out):
             np.testing.assert_allclose(cy, my, rtol=1e-5, atol=1e-5)
-
-
-def check_output(model, x, filename, out_keys=None, opset_version=None):
-    model.xp.random.seed(42)
-
-    os.makedirs(TEST_OUT_DIR, exist_ok=True)
-    filename = os.path.join(TEST_OUT_DIR, filename)
-
-    if opset_version is None:
-        opset_version = onnx.defs.onnx_opset_version()
-    if not ONNXRUNTIME_AVAILABLE:
-        raise ImportError('check_output requires onnxruntime.')
-
-    chainer.config.train = False
-
-    # Forward computation
-    if isinstance(x, (list, tuple)):
-        for i in x:
-            assert isinstance(i,
-                              chainer.get_array_types() + (chainer.Variable,))
-        chainer_out = model(*x)
-        x_rt = tuple(
-            _x.array if isinstance(_x, chainer.Variable) else _x for _x in x)
-    elif isinstance(x, dict):
-        chainer_out = model(**x)
-        x_rt = tuple(_x.array if isinstance(_x, chainer.Variable) else _x
-                     for _, _x in x.items())
-    elif isinstance(x, chainer.get_array_types()):
-        chainer_out = model(chainer.Variable(x))
-        x_rt = x,
-    elif isinstance(x, chainer.Variable):
-        chainer_out = model(x)
-        x_rt = x.array,
-    else:
-        raise ValueError(
-            'The \'x\' argument should be a list, tuple or dict of '
-            'numpy.ndarray or chainer.Variable, or simply a numpy.ndarray or a'
-            ' chainer.Variable itself. But a {} object was given.'.format(
-                type(x)))
-
-    rt_out_keys = None
-    if isinstance(chainer_out, (list, tuple)):
-        chainer_out = tuple(y.array for y in chainer_out)
-        if out_keys is not None:
-            assert len(out_keys) == len(chainer_out)
-            rt_out_keys = out_keys
-    elif isinstance(chainer_out, dict):
-        if len(out_keys) > 1:
-            rt_out_keys = out_keys
-        chainer_outs = [chainer_out[k] for k in out_keys]
-        chainer_out = tuple(out.array if isinstance(out, chainer.Variable) else
-                            out for out in chainer_outs)
-    elif isinstance(chainer_out, chainer.Variable):
-        chainer_out = (chainer_out.array,)
-    else:
-        raise ValueError('Unknown output type: {}'.format(type(chainer_out)))
-
-    x_rt = tuple(chainer.cuda.to_cpu(x) for x in x_rt)
-    chainer_out = tuple(chainer.cuda.to_cpu(x) for x in chainer_out)
-
-    onnx_model = onnx_chainer.export(model, x, filename,
-                                     opset_version=opset_version)
-    check_all_connected_from_inputs(onnx_model)
-
-    sess = rt.InferenceSession(onnx_model.SerializeToString())
-    input_names = [i.name for i in sess.get_inputs()]
-
-    # To detect unexpected inputs created by exporter, check input names
-    # TODO(disktnk): `input_names` got from onnxruntime session includes only
-    # network inputs, does not include internal inputs such as weight attribute
-    # etc. so that need to collect network inputs from `onnx_model`.
-    graph_input_names = _get_graph_input_names(onnx_model)
-    assert list(sorted(input_names)) == list(sorted(graph_input_names))
-
-    rt_out = sess.run(
-        rt_out_keys, {name: array for name, array in zip(input_names, x_rt)})
-
-    for cy, my in zip(chainer_out, rt_out):
-        np.testing.assert_allclose(cy, my, rtol=1e-5, atol=1e-5)
-
-
-def check_all_connected_from_inputs(onnx_model):
-    edge_names = set(_get_graph_input_names(onnx_model))
-    # Nodes which are not connected from the network inputs.
-    orphan_nodes = []
-    for node in onnx_model.graph.node:
-        if not edge_names.intersection(node.input):
-            orphan_nodes.append(node)
-        for output_name in node.output:
-            edge_names.add(output_name)
-    assert not(orphan_nodes), '{}'.format(orphan_nodes)
-
-
-def _get_graph_input_names(onnx_model):
-    initialized_graph_input_names = {
-        i.name for i in onnx_model.graph.initializer}
-    return [i.name for i in onnx_model.graph.input if i.name not in
-            initialized_graph_input_names]

--- a/onnx_chainer/testing/test_onnxruntime.py
+++ b/onnx_chainer/testing/test_onnxruntime.py
@@ -15,11 +15,6 @@ except ImportError:
     ONNXRUNTIME_AVAILABLE = False
 
 
-MINIMUM_OPSET_VERSION = 7
-
-TEST_OUT_DIR = 'out'
-
-
 def check_model_expect(test_path, input_names=None):
     if not ONNXRUNTIME_AVAILABLE:
         raise ImportError('check_output requires onnxruntime.')

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ setup(
     keywords='ONNX Chainer model converter deep learning',
     install_requires=[
         'chainer>=3.2.0',
-        'onnx>=1.3.0'
+        'onnx==1.3.0'
     ],
     tests_require=[
         'chainer>=3.2.0',
-        'onnx>=1.3.0',
-        'onnxruntime>=0.1.3',
+        'onnx==1.3.0',
+        'onnxruntime==0.2.1',
         'numpy',
     ],
     license='MIT License',

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -64,6 +64,10 @@ class ONNXModelTest(unittest.TestCase):
                 onnx_model = onnx.load_model(f)
             check_all_connected_from_inputs(onnx_model)
 
+            # TODO(disktnk): `input_names` got from onnxruntime session
+            # includes only network inputs, does not include internal inputs
+            # such as weight attribute etc. so that need to collect network
+            # inputs from `onnx_model`.
             graph_input_names = _get_graph_input_names(onnx_model)
             check_model_expect(test_path, input_names=graph_input_names)
 

--- a/tests/test_export_testcase.py
+++ b/tests/test_export_testcase.py
@@ -52,4 +52,4 @@ def test_output_grad(tmpdir, model, x):
         assert os.path.isfile(
             os.path.join(path, 'test_data_set_0', 'gradient_{}.pb'.format(i)))
     assert not os.path.isfile(
-            os.path.join(path, 'test_data_set_0', 'gradient_10.pb'))
+        os.path.join(path, 'test_data_set_0', 'gradient_10.pb'))

--- a/tests/test_export_testcase.py
+++ b/tests/test_export_testcase.py
@@ -1,55 +1,55 @@
 import os
-import unittest
 
 import chainer
 import chainer.functions as F
 import chainer.links as L
 import numpy as np
+import pytest
 
-import onnx_chainer
+from onnx_chainer import export_testcase
 
 
-class TestExportTestCase(unittest.TestCase):
+@pytest.fixture(scope='function')
+def model():
+    return chainer.Sequential(
+        L.Convolution2D(None, 16, 5, 1, 2),
+        F.relu,
+        L.Convolution2D(16, 8, 5, 1, 2),
+        F.relu,
+        L.Convolution2D(8, 5, 5, 1, 2),
+        F.relu,
+        L.Linear(None, 100),
+        F.relu,
+        L.Linear(100, 10)
+    )
 
-    def setUp(self):
-        self.model = chainer.Sequential(
-            L.Convolution2D(None, 16, 5, 1, 2),
-            F.relu,
-            L.Convolution2D(16, 8, 5, 1, 2),
-            F.relu,
-            L.Convolution2D(8, 5, 5, 1, 2),
-            F.relu,
-            L.Linear(None, 100),
-            F.relu,
-            L.Linear(100, 10)
-        )
-        x = np.zeros((1, 3, 28, 28), dtype=np.float32)
-        self.x = chainer.as_variable(x)
 
-    def test_export_testcase(self):
-        # Just check the existence of pb files
-        path = 'out/test_export_testcase'
-        onnx_chainer.export_testcase(
-            self.model, (self.x,), path)
+@pytest.fixture(scope='function')
+def x():
+    return np.zeros((1, 3, 28, 28), dtype=np.float32)
 
-        assert os.path.isfile(os.path.join(path, 'model.onnx'))
-        assert os.path.isfile(os.path.join(path, 'test_data_set_0',
-                                           'input_0.pb'))
-        assert os.path.isfile(os.path.join(path, 'test_data_set_0',
-                                           'output_0.pb'))
 
-    def test_output_grad(self):
-        path = 'out/test_export_testcase_with_grad'
-        onnx_chainer.export_testcase(
-            self.model, (self.x,), path, output_grad=True, train=True)
+def test_export_testcase(tmpdir, model, x):
+    # Just check the existence of pb files
+    path = tmpdir.mkdir('test_export_testcase').dirname
+    export_testcase(model, (x,), path)
 
-        assert os.path.isfile(os.path.join(path, 'model.onnx'))
-        assert os.path.isfile(os.path.join(path, 'test_data_set_0',
-                                           'input_0.pb'))
-        assert os.path.isfile(os.path.join(path, 'test_data_set_0',
-                                           'output_0.pb'))
-        # 10 gradient files should be there
-        for i in range(10):
-            assert os.path.isfile(os.path.join(path, 'test_data_set_0',
-                                               'gradient_{}.pb'.format(i)))
-        assert i == 9
+    assert os.path.isfile(os.path.join(path, 'model.onnx'))
+    assert os.path.isfile(os.path.join(path, 'test_data_set_0', 'input_0.pb'))
+    assert os.path.isfile(os.path.join(path, 'test_data_set_0', 'output_0.pb'))
+
+
+def test_output_grad(tmpdir, model, x):
+    path = tmpdir.mkdir('test_export_testcase_with_grad').dirname
+    export_testcase(model, (x,), path, output_grad=True, train=True)
+
+    assert os.path.isfile(os.path.join(path, 'model.onnx'))
+    assert os.path.isfile(os.path.join(path, 'test_data_set_0', 'input_0.pb'))
+    assert os.path.isfile(os.path.join(path, 'test_data_set_0', 'output_0.pb'))
+
+    # 10 gradient files should be there
+    for i in range(10):
+        assert os.path.isfile(
+            os.path.join(path, 'test_data_set_0', 'gradient_{}.pb'.format(i)))
+    assert not os.path.isfile(
+            os.path.join(path, 'test_data_set_0', 'gradient_10.pb'))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,5 +1,3 @@
-import unittest
-
 import chainer
 import chainer.functions as F
 import chainer.links as L
@@ -7,10 +5,10 @@ from chainer import testing
 import numpy as np
 
 from onnx_chainer.testing import input_generator
-from onnx_chainer.testing import test_onnxruntime
+from tests.helper import ONNXModelTest
 
 
-class TestMultipleInputs(unittest.TestCase):
+class TestMultipleInputs(ONNXModelTest):
 
     def setUp(self):
 
@@ -26,30 +24,30 @@ class TestMultipleInputs(unittest.TestCase):
 
         self.model = Model()
         self.ins = (input_generator.increasing(1, 5),
-                    input_generator.increasing(1, 5),
-                    input_generator.increasing(1, 5))
-        self.fn = 'MultiInputs.onnx'
+                    input_generator.increasing(1, 5)*1.1,
+                    input_generator.increasing(1, 5)*1.2)
+        self.base_name = 'multiple_inputs'
 
     def test_arrays(self):
-        test_onnxruntime.check_output(self.model, self.ins, self.fn)
+        self.expect(self.model, self.ins, name=self.base_name+'_arrays')
 
     def test_variables(self):
         ins = [chainer.Variable(i) for i in self.ins]
-        test_onnxruntime.check_output(self.model, ins, self.fn)
+        self.expect(self.model, ins, name=self.base_name+'_vars')
 
     def test_array_dicts(self):
         arg_names = ['x', 'y', 'z']  # current exporter ignores these names
         ins = {arg_names[i]: v for i, v in enumerate(self.ins)}
-        test_onnxruntime.check_output(self.model, ins, self.fn)
+        self.expect(self.model, ins, name=self.base_name+'_dicts')
 
     def test_variable_dicts(self):
         arg_names = ['x', 'y', 'z']  # current exporter ignores these names
         ins = {arg_names[i]: chainer.Variable(v)
                for i, v in enumerate(self.ins)}
-        test_onnxruntime.check_output(self.model, ins, self.fn)
+        self.expect(self.model, ins, name=self.base_name+'_vardicts')
 
 
-class TestImplicitInput(unittest.TestCase):
+class TestImplicitInput(ONNXModelTest):
 
     def setUp(self):
 
@@ -64,11 +62,10 @@ class TestImplicitInput(unittest.TestCase):
                 return x / self.frac
 
         self.model = Model()
-        self.fn = 'ImplicitInput.onnx'
 
     def test_implicit_input(self):
         x = chainer.Variable(np.array(1, dtype=np.float32))
-        test_onnxruntime.check_output(self.model, x, self.fn)
+        self.expect(self.model, x)
 
 
 @testing.parameterize(
@@ -77,7 +74,7 @@ class TestImplicitInput(unittest.TestCase):
     {'use_bn': True, 'out_type': 'tuple'},
     {'use_bn': True, 'out_type': 'list'},
 )
-class TestMultipleOutput(unittest.TestCase):
+class TestMultipleOutput(ONNXModelTest):
 
     def get_model(self, use_bn=False, out_type=None):
         class Model(chainer.Chain):
@@ -113,14 +110,10 @@ class TestMultipleOutput(unittest.TestCase):
     def test_multiple_outputs(self):
         model = self.get_model(use_bn=self.use_bn, out_type=self.out_type)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
-        # 'out_keys' is necessary even if self.out_type is tuple or list
-        # because onnxruntime does not guarantee the order of outputs when
-        # output keys are None.
-        test_onnxruntime.check_output(
-            model, x, 'MultipleOutputs.onnx', out_keys=['Tanh_0', 'Sigmoid_0'])
+        self.expect(model, x)
 
 
-class TestIntermediateOutput(unittest.TestCase):
+class TestIntermediateOutput(ONNXModelTest):
 
     def get_model(self):
         class Model(chainer.Chain):
@@ -140,7 +133,6 @@ class TestIntermediateOutput(unittest.TestCase):
     def test_outputs(self):
         model = self.get_model()
         x = np.ones((1, 3), dtype=np.float32)
-        # TODO(disktnk) output keys are not intuitive
-        test_onnxruntime.check_output(
-            model, x, 'IntermediateOutput.onnx',
-            out_keys=['Identity_0', 'Gemm_1'])
+        # TODO(disktnk) output keys will be ['Identity_0', 'Gemm_1'], not
+        # intuitive. ONNX-Chainer should support outputs name to customize them
+        self.expect(model, x)

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -69,10 +69,10 @@ class TestImplicitInput(ONNXModelTest):
 
 
 @testing.parameterize(
-    {'use_bn': True, 'out_type': 'dict'},
-    {'use_bn': False, 'out_type': 'dict'},
-    {'use_bn': True, 'out_type': 'tuple'},
-    {'use_bn': True, 'out_type': 'list'},
+    {'use_bn': True, 'out_type': 'dict', 'condition': 'bn_out_dict'},
+    {'use_bn': False, 'out_type': 'dict', 'condition': 'out_dict'},
+    {'use_bn': True, 'out_type': 'tuple', 'condition': 'bn_out_tuple'},
+    {'use_bn': True, 'out_type': 'list', 'condition': 'bn_out_list'},
 )
 class TestMultipleOutput(ONNXModelTest):
 
@@ -110,7 +110,8 @@ class TestMultipleOutput(ONNXModelTest):
     def test_multiple_outputs(self):
         model = self.get_model(use_bn=self.use_bn, out_type=self.out_type)
         x = np.zeros((1, 3, 32, 32), dtype=np.float32)
-        self.expect(model, x)
+        name = 'multipleoutput_' + self.condition
+        self.expect(model, x, name=name)
 
 
 class TestIntermediateOutput(ONNXModelTest):

--- a/tests/test_rt.py
+++ b/tests/test_rt.py
@@ -1,15 +1,11 @@
-import unittest
-
 import chainer
 import chainer.functions as F
 import chainer.links as L
 from chainer.testing import attr
 import numpy as np
-import onnx
 
 import chainercv.links as C
-import onnx_chainer
-from onnx_chainer.testing import test_onnxruntime
+from tests.helper import ONNXModelTest
 
 
 def _to_gpu(model, x):
@@ -19,7 +15,7 @@ def _to_gpu(model, x):
     return model, x
 
 
-class TestLeNet5(unittest.TestCase):
+class TestLeNet5(ONNXModelTest):
 
     def setUp(self):
         self.model = chainer.Sequential(
@@ -34,49 +30,33 @@ class TestLeNet5(unittest.TestCase):
             L.Linear(100, 10)
         )
         self.x = np.zeros((1, 3, 28, 28), dtype=np.float32)
-        self.fn = 'LeNet5.onnx'
-
-    def check_output(self, model, x):
-        for opset_version in range(
-                onnx_chainer.MINIMUM_OPSET_VERSION,
-                onnx.defs.onnx_opset_version() + 1):
-            test_onnxruntime.check_output(
-                model, x, self.fn, opset_version=opset_version)
 
     def test_output(self):
-        self.check_output(self.model, self.x)
+        self.expect(self.model, self.x)
 
     @attr.gpu
     def test_output_gpu(self):
         model, x = _to_gpu(self.model, self.x)
-        self.check_output(model, x)
+        self.expect(model, x)
 
 
-class TestVGG16(unittest.TestCase):
+class TestVGG16(ONNXModelTest):
 
     def setUp(self):
         self.model = C.VGG16(
             pretrained_model=None, initialW=chainer.initializers.Uniform(1))
         self.x = np.zeros((1, 3, 224, 224), dtype=np.float32)
-        self.fn = 'VGG16.onnx'
-
-    def check_output(self, model, x):
-        for opset_version in range(
-                onnx_chainer.MINIMUM_OPSET_VERSION,
-                onnx.defs.onnx_opset_version() + 1):
-            test_onnxruntime.check_output(
-                model, x, self.fn, opset_version=opset_version)
 
     def test_output(self):
-        self.check_output(self.model, self.x)
+        self.expect(self.model, self.x)
 
     @attr.gpu
     def test_output_gpu(self):
         model, x = _to_gpu(self.model, self.x)
-        self.check_output(model, x)
+        self.expect(model, x)
 
 
-class TestResNet50(unittest.TestCase):
+class TestResNet50(ONNXModelTest):
 
     def setUp(self):
         self.model = C.ResNet50(
@@ -85,19 +65,11 @@ class TestResNet50(unittest.TestCase):
         self.model.pool1 = lambda x: F.max_pooling_2d(
             x, ksize=3, stride=2, cover_all=False)
         self.x = np.zeros((1, 3, 224, 224), dtype=np.float32)
-        self.fn = 'ResNet50.onnx'
-
-    def check_output(self, model, x):
-        for opset_version in range(
-                onnx_chainer.MINIMUM_OPSET_VERSION,
-                onnx.defs.onnx_opset_version() + 1):
-            test_onnxruntime.check_output(
-                model, x, self.fn, opset_version=opset_version)
 
     def test_output(self):
-        self.check_output(self.model, self.x)
+        self.expect(self.model, self.x)
 
     @attr.gpu
     def test_output_gpu(self):
         model, x = _to_gpu(self.model, self.x)
-        self.check_output(model, x)
+        self.expect(model, x)


### PR DESCRIPTION
- `test_rt.py` and `test_input.py` are applied `ONNXModelTest`, these tests also make "model.onnx" + test_data_sets, and check output value by test runtime
- `test_export_testcase.py` is fixed not to put ONNX files to "out" directory, use temporary directory instead. Output files are not used for other test tool.
- fixed onnxruntime and onnx version
- fixed #126 