### PR TITLE
Fix parameter name, not to use '/'

### DIFF
--- a/onnx_chainer/context.py
+++ b/onnx_chainer/context.py
@@ -3,7 +3,8 @@ class Context(object):
     def __init__(self, model):
         self.name_list = dict()
         for name, param in model.namedparams():
-            self.name_list[str(id(param))] = name
+            replaced_name = 'param' + name.replace('/', '_')
+            self.name_list[str(id(param))] = replaced_name
 
     def get_name(self, variable):
         str_id = str(id(variable))


### PR DESCRIPTION
To be favor to C identify syntax rule

before

![image](https://user-images.githubusercontent.com/414255/54067088-8a976180-427e-11e9-8404-5e0d54f962f8.png)


after

![image](https://user-images.githubusercontent.com/414255/54067076-63409480-427e-11e9-9fa5-5215bb8197dc.png)
