### PR TITLE
Change constant value type as scaler

### DIFF
--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -14,8 +14,7 @@ def convert_Add(func, opset_version, input_names, num_outputs,
 
 def convert_AddConstant(func, opset_version, input_names,
                         num_outputs, context, parameters):
-    value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
+    value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(context.get_name(value_param))
@@ -88,8 +87,7 @@ def convert_Absolute(func, opset_version, input_names,
 
 def convert_PowVarConst(func, opset_version, input_names,
                         num_outputs, context, parameters):
-    value = np.asarray([func.value], dtype=func.inputs[0].dtype)
-    value = np.broadcast_to(value, func.inputs[0].shape)
+    value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(context.get_name(value_param))


### PR DESCRIPTION
similar fixiing to #114 

took over #47, but goal is not same. If demand would come, to support runtime which not supports broadcasting, required to fix by another PR (but not we have a plan to support currently).