### PR TITLE
Move rename_tensor to function_hook

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -174,6 +174,17 @@ class ONNXExport(chainer.FunctionHook):
         self.converted_nodes[temp_node_name] = nodes
 
     def deleted(self, function=None):
+        """Rename output names.
+
+        When renaming an output name, another node can reference the same value
+        as input, so the input name must be renamed at once. So this renaming
+        process should be run after all functions are converted and this
+        `deleted` function is called when function hook is done, means
+        completed functions converting.
+
+        If input/output name is given by externally, these given names take
+        priority over named by this process.
+        """
         func_name_counts = collections.defaultdict(int)
         names = {}
         for temp_func_name, nodes in reversed(self.converted_nodes.items()):

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -179,10 +179,10 @@ class ONNXExport(chainer.FunctionHook):
         When renaming an output name, another node can reference the same value
         as input, so the input name must be renamed at once. So this renaming
         process should be run after all functions are converted and this
-        `deleted` function is called when function hook is done, means
-        completed functions converting.
+        `deleted` function is called when function hook is done, which means
+        all functions are converted.
 
-        If input/output name is given by externally, these given names take
+        If input/output names are given externally, these given names take
         priority over named by this process.
         """
         func_name_counts = collections.defaultdict(int)

--- a/tests/test_export_testcase.py
+++ b/tests/test_export_testcase.py
@@ -47,7 +47,8 @@ def test_export_testcase(
     output_pb_path = os.path.join(path, 'test_data_set_0', 'output_0.pb')
     assert os.path.isfile(output_pb_path)
     output_tensor = onnx.load_tensor(output_pb_path)
-    assert output_tensor.name == (out_names[0] if out_names else 'Gemm_1')
+    assert output_tensor.name == (
+        out_names[0] if out_names else 'LinearFunction_1')
 
 
 def test_output_grad(tmpdir, model, x, desable_experimental_warning):


### PR DESCRIPTION
Move `rename_tensor` function to `FunctionHook.deleted` function, to be more customizable.

- rename output node, using Chainer's `FunctionNode` name, not ONNX operator name. This change **breaks backward compatibility**
- set `FunctionNode` name as node name
  - along with set doc_string for systematically reason

![image](https://user-images.githubusercontent.com/414255/54348005-83f85800-468b-11e9-87ab-98472bd061c7.png)
