### PR TITLE
Add output type check

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -388,6 +388,8 @@ def _export(model, args, filename, export_params, graph_name, save_text,
     else:
         raise RuntimeError(
             'Unexpected output type from the model: {}'.format(type(outputs)))
+    if not all([isinstance(o, chainer.Variable) for o in flat_outputs]):
+        raise ValueError('The all \'outputs\' must be Chainer Variable')
     network_outputs = {context.get_name(var): var for var in flat_outputs}
     if output_names:
         rename_variable_name(context, outputs, network_outputs, output_names)


### PR DESCRIPTION
If the target model returns tuple of ndarray or other value besides `chainer.Variable`, exporter cannot make computational graph using variable backword. For example, the error message reported in #128 is probably caused by outputs, the target model returns a tuple, and the tuple includes ndarray. On this code https://github.com/chainer/chainercv/blob/v0.12.0/chainercv/links/model/faster_rcnn/faster_rcnn.py#L159 , `roi` and `roi_indices` is `ndarray`, not `chainer.Variable`

This PR prevent from exporting when `flat_output` includes not `chainer.Variable` type.