### PR TITLE
Export `resize_images` as `Upsample` ONNX op

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Currently 59 Chainer Functions are supported to export in ONNX format.
 - Squeeze
 - Tile
 - Transpose
+- ResizeImages
 
 ### Connection
 

--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -24,6 +24,7 @@ from onnx_chainer.functions.array import convert_Squeeze  # NOQA
 from onnx_chainer.functions.array import convert_Tile  # NOQA
 from onnx_chainer.functions.array import convert_Transpose  # NOQA
 from onnx_chainer.functions.array import convert_Where  # NOQA
+from onnx_chainer.functions.array import convert_ResizeImages  # NOQA
 
 from onnx_chainer.functions.connection import convert_Convolution2DFunction  # NOQA
 from onnx_chainer.functions.connection import convert_ConvolutionND  # NOQA

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -1,7 +1,8 @@
+import warnings
+
 import chainer
 import numpy as np
 from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
-import warnings # for print warnings on `resize_images`
 
 from onnx_chainer.functions.opset_version import support
 from onnx_chainer import onnx_helper
@@ -323,7 +324,7 @@ def convert_Where(func, opset_version, input_names, num_outputs, context,
 # Use `Reshape` for opset 10
 @support((7, 9))
 def convert_ResizeImages(func, opset_version, input_names, num_outputs,
-                        context, parameters):
+                         context, parameters):
 
     warnings.warn(
         '`resize_images` is mapped to `Upsampling` ONNX op with bilinear '
@@ -340,15 +341,15 @@ def convert_ResizeImages(func, opset_version, input_names, num_outputs,
     # Compute scaling factor.
     # NOTE(syoyo): Despite of its name, `Upsample` onnx op will downsample
     # images when scale value is less than 1.0
-    scales = [1.0, 1.0, float(outsize[0]) / float(h), float(outsize[1]) / float(w)]
+    scales = [1.0, 1.0, float(outsize[0]) / float(h),
+              float(outsize[1]) / float(w)]
 
     if (scales[2] < 1.0e-8) and (scales[3] < 1.0e-8):
         raise ValueError(
             'scaling factor is too small or zero. scales for h = {}, scales for w = {}'.format(scales[2], scales[3]))
 
-
     # resize_images in Chainer only supports bilinear interpolation
-    mode = 'linear' # Actually this will be mapped to 'bilinear' in onnxruntime
+    mode = 'linear'  # Actually this will be mapped to 'bilinear' in onnxruntime
     if opset_version == 7:
         return onnx_helper.make_node('Upsample', input_names, num_outputs,
                                      scales=scales, mode=mode),

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -338,7 +338,7 @@ def convert_ResizeImages(func, opset_version, input_names, num_outputs,
 
 
     # resize_images in Chainer only supports bilinear interpolation
-    mode = 'bilinear'
+    mode = 'linear' # Actually this will be mapped to 'bilinear' in onnxruntime
     if opset_version == 7:
         return onnx_helper.make_node('Upsample', input_names, num_outputs,
                                      scales=scales, mode=mode),

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -341,10 +341,10 @@ def convert_ResizeImages(func, opset_version, input_names, num_outputs,
     mode = 'bilinear'
     if opset_version == 7:
         return onnx_helper.make_node('Upsample', input_names, num_outputs,
-                                     scales=scales, mode=mode)
+                                     scales=scales, mode=mode),
     if opset_version == 9:
         scales = np.array(scales, dtype=np.float32)
         scales_param = chainer.Parameter(scales)
         parameters.append(scales_param)
         input_names.append(context.get_name(scales_param))
-        return onnx_helper.make_node('Upsample', input_names, num_outputs, mode=mode)
+        return onnx_helper.make_node('Upsample', input_names, num_outputs, mode=mode),

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -1,6 +1,7 @@
 import chainer
 import numpy as np
 from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
+import warnings # for print warnings on `resize_images`
 
 from onnx_chainer.functions.opset_version import support
 from onnx_chainer import onnx_helper
@@ -323,6 +324,15 @@ def convert_Where(func, opset_version, input_names, num_outputs, context,
 @support((7, 9))
 def convert_ResizeImages(func, opset_version, input_names, num_outputs,
                         context, parameters):
+
+    warnings.warn(
+        '`resize_images` is mapped to `Upsampling` ONNX op with bilinear '
+        'interpolation. '
+        'Behavior of bilinear interpolation differs from each implementation. '
+        'See the issue https://github.com/chainer/onnx-chainer/issues/147 '
+        'for details.',
+        UserWarning)
+
     outsize = (func.out_H, func.out_W)
 
     h, w = func.inputs[0].shape[2:]

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -31,6 +31,7 @@ _supported_function_node_set = {
     'Tile',
     'Transpose',
     'Where',
+    'ResizeImages',
 
     # Connection
     'Convolution2DFunction',
@@ -86,6 +87,7 @@ _supported_function_node_set = {
 
     # Loss
     'SoftmaxCrossEntropy',
+
 }
 
 _converters = None

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -214,20 +214,26 @@ class TestResizeImages(ONNXModelTest):
                 self.args[self.input_argname] = x
                 return self.ops(**self.args)
 
+        # (batch, channel, height, width) = (1, 1, 2, 2)
+        self.x = np.array([[[[64, 32], [64, 32]]]], np.float32)
+
+        # 2x upsampling
         args = {'output_shape' : (4, 4)}
         self.model = Model(F.resize_images, args, 'x')
-
-        # (batch, channel, height, width)
-        #self.x = input_generator.increasing(1, 1, 2, 2)
-        self.x = np.array([[[[64, 32], [64, 32]]]], np.float32)
 
     def test_output(self):
 
         # FIXME(syoyo): Currently the test will fail due to different behavior
         # of bilinear interpolation between Chainer and onnxruntime.
-        # Expected bevhavior would be [64, 54, 40, 32].
-        # (cv2.resize and tensorflow master(r1.14 or r2.0) after this fix: https://github.com/tensorflow/tensorflow/issues/6720)
-        # Currently Chainer will give [64, ], while onnxruntime gives [64, 48, 32, 32](same result with tensorflow r1.13 or older with `align_corners=True)
+        #
+        # Currently Chainer will give [64, 53.333336, 42.666668, 32]
+        # (same result with tensorflow r1.13.1 with `align_corners=True`),
+        # while onnxruntime gives [64, 48, 32, 32]
+        # (same result with tensorflow r1.13.1 with `align_corners=False`)
+        #
+        # Even though, expected bevhavior will be [64, 54, 40, 32].
+        # (cv2.resize and tensorflow master(r1.14 or r2.0) after this fix:
+        #  https://github.com/tensorflow/tensorflow/issues/6720)
 
         # TODO(hamaji): onnxruntime does not support Upsample-9 yet.
         # https://github.com/chainer/onnx-chainer/issues/111

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -223,17 +223,19 @@ class TestResizeImages(ONNXModelTest):
 
     def test_output(self):
 
-        # FIXME(syoyo): Currently the test will fail due to different behavior
-        # of bilinear interpolation between Chainer and onnxruntime.
+        # FIXME(syoyo): Currently the test will fail due to the different               # behavior of bilinear interpolation between Chainer and onnxruntime.
+        # So disable output value check for a while.
         #
         # Currently Chainer will give [64, 53.333336, 42.666668, 32]
         # (same result with tensorflow r1.13.1 with `align_corners=True`),
         # while onnxruntime gives [64, 48, 32, 32]
         # (same result with tensorflow r1.13.1 with `align_corners=False`)
         #
-        # Even though, expected bevhavior will be [64, 54, 40, 32].
+        # However, the correct bevhavior will be [64, 54, 40, 32].
         # (cv2.resize and tensorflow master(r1.14 or r2.0) after this fix:
         #  https://github.com/tensorflow/tensorflow/issues/6720)
+
+        self.check_out_values = None # Skip output value check
 
         # TODO(hamaji): onnxruntime does not support Upsample-9 yet.
         # https://github.com/chainer/onnx-chainer/issues/111

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -142,9 +142,10 @@ from tests.helper import ONNXModelTest
      'name': 'expand_dims_minus2'},
 
     # resize_images
+    # TODO(syoyo): Write a dedicated tester for resize_images. Add test for other scales 
     {'ops': 'resize_images', 'input_shape': (1, 3, 6, 6),
      'input_argname': 'x',
-     'args': {'output_shape': (8, 8)}},
+     'args': {'output_shape': (6, 6)}}, # scales = (1.0, 1.0)
 )
 class TestArrayOperators(ONNXModelTest):
 
@@ -169,7 +170,14 @@ class TestArrayOperators(ONNXModelTest):
         name = self.ops
         if hasattr(self, 'name'):
             name = self.name
-        self.expect(self.model, self.x, name=name)
+
+        # TODO(hamaji): onnxruntime does not support Upsample-9 yet.
+        # https://github.com/chainer/onnx-chainer/issues/111
+        skip_opset_version = []
+        if name == 'resize_images':
+            skip_opset_version.append(9)
+        self.expect(self.model, self.x, name=name,
+                    skip_opset_version=skip_opset_version)
 
 
 class TestConcat(ONNXModelTest):

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -140,6 +140,11 @@ from tests.helper import ONNXModelTest
     {'ops': 'expand_dims', 'input_shape': (3,),
      'input_argname': 'x', 'args': {'axis': -2},
      'name': 'expand_dims_minus2'},
+
+    # resize_images
+    {'ops': 'resize_images', 'input_shape': (1, 3, 6, 6),
+     'input_argname': 'x',
+     'args': {'output_shape': (8, 8)}},
 )
 class TestArrayOperators(ONNXModelTest):
 

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -198,6 +198,7 @@ class TestWhere(ONNXModelTest):
         y = np.zeros((2, 3), np.float32)
         self.expect(model, (cond, x, y), skip_opset_version=[7, 8])
 
+
 class TestResizeImages(ONNXModelTest):
 
     def setUp(self):
@@ -218,7 +219,7 @@ class TestResizeImages(ONNXModelTest):
         self.x = np.array([[[[64, 32], [64, 32]]]], np.float32)
 
         # 2x upsampling
-        args = {'output_shape' : (4, 4)}
+        args = {'output_shape': (4, 4)}
         self.model = Model(F.resize_images, args, 'x')
 
     def test_output(self):
@@ -231,12 +232,13 @@ class TestResizeImages(ONNXModelTest):
         # while onnxruntime gives [64, 48, 32, 32]
         # (same result with tensorflow r1.13.1 with `align_corners=False`)
         #
-        # However, the correct bevhavior will be [64, 54, 40, 32].
+        # However, the correct behavior will be [64, 54, 40, 32].
         # (cv2.resize and tensorflow master(r1.14 or r2.0) after this fix:
         #  https://github.com/tensorflow/tensorflow/issues/6720)
 
-        self.check_out_values = None # Skip output value check
+        self.check_out_values = None  # Skip output value check
 
         # TODO(hamaji): onnxruntime does not support Upsample-9 yet.
         # https://github.com/chainer/onnx-chainer/issues/111
-        self.expect(self.model, self.x, name='resize_images', skip_opset_version=[9])
+        self.expect(self.model, self.x, name='resize_images',
+                    skip_opset_version=[9])


### PR DESCRIPTION
As described in this issue, there is an inconsistency of the behavior of bilinear interpolation between Chainer `resize_images` and ONNX(onnxruntime) `Upsample`.

For a while, output value check in testers is disabled as pointed by @disktnk 

https://github.com/chainer/onnx-chainer/issues/147
