### PR TITLE
fix to manage each var is renamed or not

### DIFF
--- a/onnx_chainer/context.py
+++ b/onnx_chainer/context.py
@@ -38,12 +38,12 @@ class Context(object):
         Arguments:
             variable (var): target variable
             name (str): name to be exported as ONNX node name
-            pinned (bool): if don't want to change the name on subsequent
-                process, set ``True``. Enable to check the target variable
-                is pinned or not by using ``is_pinned``.
+            pinned (bool): if ``True``, the name will not be overwritten in
+                subsequence process.
         """
 
         str_id = id(variable)
+        assert str_id not in self.name_list or not self.name_list[str_id][1]
         self.name_list[str_id] = (name, pinned)
         if isinstance(variable, (chainer.Variable, chainer.Parameter)):
             array_id = id(variable.array)


### PR DESCRIPTION
fixes #154 

before

![image](https://user-images.githubusercontent.com/414255/56485669-edcc1300-650f-11e9-84cb-cc7396243167.png)

export with `output_names=['out_tanh', 'out_sigmoid']`, outputs are renamed but interim node output are not renamed, such as `v15`

after

![image](https://user-images.githubusercontent.com/414255/56485733-34ba0880-6510-11e9-8777-0259123e8b4d.png)
