### PR TITLE
desable -> disable spelling correction.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope='function')
-def desable_experimental_warning():
+def disable_experimental_warning():
     org_config = chainer.disable_experimental_feature_warning
     chainer.disable_experimental_feature_warning = True
     try:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -12,7 +12,7 @@ from onnx_chainer.testing.get_test_data_set import gen_test_data_set
 class ONNXModelTest(unittest.TestCase):
 
     @pytest.fixture(autouse=True)
-    def set_config(self, desable_experimental_warning):
+    def set_config(self, disable_experimental_warning):
         pass
 
     @pytest.fixture(autouse=True, scope='function')

--- a/tests/test_export_testcase.py
+++ b/tests/test_export_testcase.py
@@ -33,7 +33,7 @@ def x():
 @pytest.mark.parametrize('in_names,out_names',
                          [(None, None), (['x'], ['y'])])
 def test_export_testcase(
-        tmpdir, model, x, desable_experimental_warning, in_names, out_names):
+        tmpdir, model, x, disable_experimental_warning, in_names, out_names):
     # Just check the existence of pb files
     path = tmpdir.mkdir('test_export_testcase').dirname
     export_testcase(model, (x,), path,
@@ -51,7 +51,7 @@ def test_export_testcase(
         out_names[0] if out_names else 'LinearFunction_1')
 
 
-def test_output_grad(tmpdir, model, x, desable_experimental_warning):
+def test_output_grad(tmpdir, model, x, disable_experimental_warning):
     path = tmpdir.mkdir('test_export_testcase_with_grad').dirname
     export_testcase(model, (x,), path, output_grad=True, train=True)
 


### PR DESCRIPTION
This PR simply corrects the spelling `desable` -> `disable` 