### PR TITLE
Revert output_names on converter to deal with fan-out node

### DIFF
--- a/onnx_chainer/functions/activation.py
+++ b/onnx_chainer/functions/activation.py
@@ -1,51 +1,52 @@
+import onnx
+
 from onnx_chainer.functions.opset_version import support
-from onnx_chainer import onnx_helper
 
 
 @support((1, 6))
 def convert_ClippedReLU(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Clip', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Clip', input_names, output_names,
             min=0.0, max=func.cap,
             consumed_inputs=[1]
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'Clip', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Clip', input_names, output_names,
             min=0.0, max=func.cap,
         ),
 
 
 @support((1, 6))
-def convert_ELU(func, opset_version, input_names, num_outputs,
+def convert_ELU(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Elu', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Elu', input_names, output_names,
             alpha=func.alpha,
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'Elu', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Elu', input_names, output_names,
             alpha=func.alpha
         ),
 
 
 @support((1, 6))
 def convert_HardSigmoid(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'HardSigmoid', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'HardSigmoid', input_names, output_names,
             alpha=0.2,
             beta=0.5,
             consumed_inputs=[1],
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'HardSigmoid', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'HardSigmoid', input_names, output_names,
             alpha=0.2,
             beta=0.5
         ),
@@ -53,81 +54,81 @@ def convert_HardSigmoid(func, opset_version, input_names,
 
 @support((1, 6))
 def convert_LeakyReLU(func, opset_version, input_names,
-                      num_outputs, context, parameters):
+                      output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'LeakyRelu', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'LeakyRelu', input_names, output_names,
             alpha=func.slope,
             consumed_inputs=[1],
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'LeakyRelu', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'LeakyRelu', input_names, output_names,
             alpha=func.slope
         ),
 
 
 def convert_LogSoftmax(func, opset_version, input_names,
-                       num_outputs, context, parameters):
-    return onnx_helper.make_node(
-        'LogSoftmax', input_names, num_outputs,
+                       output_names, context, parameters):
+    return onnx.helper.make_node(
+        'LogSoftmax', input_names, output_names,
         axis=1
     ),
 
 
 @support((1, 6, 7))
 def convert_PReLUFunction(func, opset_version, input_names,
-                          num_outputs, context, parameters):
+                          output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'PRelu', input_names, num_outputs, consumed_inputs=[1]),
+        return onnx.helper.make_node(
+            'PRelu', input_names, output_names, consumed_inputs=[1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('PRelu', input_names, num_outputs),
+        return onnx.helper.make_node('PRelu', input_names, output_names),
     elif opset_version == 7:
-        return onnx_helper.make_node('PRelu', input_names, num_outputs),
+        return onnx.helper.make_node('PRelu', input_names, output_names),
 
 
 @support((1, 6))
-def convert_ReLU(func, opset_version, input_names, num_outputs,
+def convert_ReLU(func, opset_version, input_names, output_names,
                  context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Relu', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Relu', input_names, output_names,
             consumed_inputs=[1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Relu', input_names, num_outputs),
+        return onnx.helper.make_node('Relu', input_names, output_names),
 
 
 @support((1, 6))
 def convert_Sigmoid(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Sigmoid', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Sigmoid', input_names, output_names,
             consumed_inputs=[1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Sigmoid', input_names, num_outputs),
+        return onnx.helper.make_node('Sigmoid', input_names, output_names),
 
 
 def convert_Softmax(func, opset_version, input_names,
-                    num_outputs, context, parameters):
-    return onnx_helper.make_node(
-        'Softmax', input_names, num_outputs,
+                    output_names, context, parameters):
+    return onnx.helper.make_node(
+        'Softmax', input_names, output_names,
         axis=func.axis
     ),
 
 
 def convert_Softplus(func, opset_version, input_names,
-                     num_outputs, context, parameters):
-    return onnx_helper.make_node('Softplus', input_names, num_outputs),
+                     output_names, context, parameters):
+    return onnx.helper.make_node('Softplus', input_names, output_names),
 
 
 @support((1, 6))
-def convert_Tanh(func, opset_version, input_names, num_outputs,
+def convert_Tanh(func, opset_version, input_names, output_names,
                  context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Tanh', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Tanh', input_names, output_names,
             consumed_inputs=[1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Tanh', input_names, num_outputs),
+        return onnx.helper.make_node('Tanh', input_names, output_names),

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -353,16 +353,16 @@ def convert_Repeat(func, opset_version, input_names, output_names, context,
         scales[axis] = float(repeats[0])
 
     if opset_version == 7:
-        gb.op('Upsample', inputs, scales=scales)
-        return gb.nodes(output_names=output_names)
+        gb.op_output_named('Upsample', inputs, output_names, scales=scales)
+        return gb.nodes()
 
     if opset_version == 9:
         scales = np.array(scales, dtype=np.float32)
         scales_param = chainer.Parameter(scales)
         parameters.append(scales_param)
         inputs.append(context.get_name(scales_param))
-        gb.op('Upsample', inputs)
-        return gb.nodes(output_names=output_names)
+        gb.op_output_named('Upsample', inputs, output_names)
+        return gb.nodes()
 
 
 # NOTE(syoyo): `Upsampling` is deprecated in ONNX opset 10.
@@ -419,8 +419,8 @@ def convert_Stack(func, opset_version, input_names, output_names, context,
 
     # To use concat op, reshape every inputs add new axes
     inputs = [gb.op('Unsqueeze', [name], axes=[axis]) for name in input_names]
-    gb.op('Concat', inputs, axis=axis)
-    return gb.nodes(output_names=output_names)
+    gb.op_output_named('Concat', inputs, output_names, axis=axis)
+    return gb.nodes()
 
 
 def convert_Hstack(func, opset_version, input_names, output_names, context,
@@ -434,8 +434,8 @@ def convert_Hstack(func, opset_version, input_names, output_names, context,
         axis = 0
     elif input0_ndim == 1:
         axis = 0
-    gb.op('Concat', inputs, axis=axis)
-    return gb.nodes(output_names=output_names)
+    gb.op_output_named('Concat', inputs, output_names, axis=axis)
+    return gb.nodes()
 
 
 def convert_Vstack(func, opset_version, input_names, output_names, context,
@@ -448,8 +448,8 @@ def convert_Vstack(func, opset_version, input_names, output_names, context,
                   name in input_names]
     elif input0_ndim == 1:
         inputs = [gb.op('Unsqueeze', [name], axes=[0]) for name in input_names]
-    gb.op('Concat', inputs, axis=0)
-    return gb.nodes(output_names=output_names)
+    gb.op_output_named('Concat', inputs, output_names, axis=0)
+    return gb.nodes()
 
 
 def convert_Dstack(func, opset_version, input_names, output_names, context,
@@ -465,5 +465,5 @@ def convert_Dstack(func, opset_version, input_names, output_names, context,
                   name in input_names]
     elif input0_ndim == 2:
         inputs = [gb.op('Unsqueeze', [name], axes=[2]) for name in input_names]
-    gb.op('Concat', inputs, axis=2)
-    return gb.nodes(output_names=output_names)
+    gb.op_output_named('Concat', inputs, output_names, axis=2)
+    return gb.nodes()

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -2,6 +2,7 @@ import warnings
 
 import chainer
 import numpy as np
+import onnx
 from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
 
 from onnx_chainer.functions.opset_version import support
@@ -29,53 +30,53 @@ TENSOR_TYPE_TO_NAME = {
 
 
 @support((1, 6))
-def convert_Cast(func, opset_version, input_names, num_outputs,
+def convert_Cast(func, opset_version, input_names, output_names,
                  context, parameters):
     typ = func.type if isinstance(func.type, np.dtype) else np.dtype(func.type)
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Cast', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Cast', input_names, output_names,
             to=TENSOR_TYPE_TO_NAME[NP_TYPE_TO_TENSOR_TYPE[typ]]
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'Cast', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Cast', input_names, output_names,
             to=NP_TYPE_TO_TENSOR_TYPE[typ]
         ),
 
 
 @support((1, 4))
 def convert_Concat(func, opset_version, input_names,
-                   num_outputs, context, parameters):
+                   output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Concat', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Concat', input_names, output_names,
             axis=func.axis
         ),
     elif opset_version == 4:
-        return onnx_helper.make_node(
-            'Concat', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Concat', input_names, output_names,
             axis=func.axis
         ),
 
 
-def convert_Copy(func, opset_version, input_names, num_outputs,
+def convert_Copy(func, opset_version, input_names, output_names,
                  context, parameters):
-    return onnx_helper.make_node(
-        'Identity', input_names, num_outputs
+    return onnx.helper.make_node(
+        'Identity', input_names, output_names
     ),
 
 
 def convert_Depth2Space(func, opset_version, input_names,
-                        num_outputs, context, parameters):
-    return onnx_helper.make_node(
-        'DepthToSpace', input_names, num_outputs,
+                        output_names, context, parameters):
+    return onnx.helper.make_node(
+        'DepthToSpace', input_names, output_names,
         blocksize=func.r
     ),
 
 
 def convert_GetItem(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     x = func.inputs[0]
     axes, starts, ends = [], [], []
     squeeze_idxs, unsqueeze_idxs = [], []
@@ -130,11 +131,11 @@ def convert_GetItem(func, opset_version, input_names,
         output = gb.op('Unsqueeze', [output],
                        axes=unsqueeze_idxs)
 
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)
 
 
 @support((1, 2))
-def convert_Pad(func, opset_version, input_names, num_outputs,
+def convert_Pad(func, opset_version, input_names, output_names,
                 context, parameters):
     if func.mode not in ['constant', 'reflect', 'edge']:
         raise ValueError(
@@ -160,30 +161,30 @@ def convert_Pad(func, opset_version, input_names, num_outputs,
             values = float(values)
 
         if opset_version == 1:
-            node = onnx_helper.make_node(
-                'Pad', input_names, num_outputs,
+            node = onnx.helper.make_node(
+                'Pad', input_names, output_names,
                 mode=func.mode,
                 paddings=pad,
                 value=values
             )
         elif opset_version == 2:
-            node = onnx_helper.make_node(
-                'Pad', input_names, num_outputs,
+            node = onnx.helper.make_node(
+                'Pad', input_names, output_names,
                 mode=func.mode,
                 pads=pad,
                 value=values
             )
     else:
         if opset_version == 1:
-            node = onnx_helper.make_node(
-                'Pad', input_names, num_outputs,
+            node = onnx.helper.make_node(
+                'Pad', input_names, output_names,
                 mode=func.mode,
                 paddings=pad,
                 value=0.,
             )
         elif opset_version == 2:
-            node = onnx_helper.make_node(
-                'Pad', input_names, num_outputs,
+            node = onnx.helper.make_node(
+                'Pad', input_names, output_names,
                 mode=func.mode,
                 pads=pad,
                 value=0.,
@@ -194,10 +195,10 @@ def convert_Pad(func, opset_version, input_names, num_outputs,
 
 @support((1, 5))
 def convert_Reshape(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Reshape', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Reshape', input_names, output_names,
             shape=func.shape
         ),
     elif opset_version == 5:
@@ -206,22 +207,22 @@ def convert_Reshape(func, opset_version, input_names,
         parameters.append(shape_param)
         input_names.append(context.get_name(shape_param))
 
-        return onnx_helper.make_node(
-            'Reshape', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Reshape', input_names, output_names,
         ),
 
 
 def convert_Space2Depth(func, opset_version, input_names,
-                        num_outputs, context, parameters):
-    return onnx_helper.make_node(
-        'SpaceToDepth', input_names, num_outputs,
+                        output_names, context, parameters):
+    return onnx.helper.make_node(
+        'SpaceToDepth', input_names, output_names,
         blocksize=func.r
     ),
 
 
 @support((1, 2))
 def convert_SplitAxis(func, opset_version, input_names,
-                      num_outputs, context, parameters):
+                      output_names, context, parameters):
     if func.indices is not None:
         indices_or_sections = func.indices
     else:
@@ -238,21 +239,21 @@ def convert_SplitAxis(func, opset_version, input_names,
         split = [length for _ in range(indices_or_sections)]
 
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Split', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Split', input_names, output_names,
             axis=func.axis,
             split=split
         ),
     elif opset_version == 2:
-        return onnx_helper.make_node(
-            'Split', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Split', input_names, output_names,
             axis=func.axis,
             split=split
         ),
 
 
 def convert_Squeeze(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     if func.axis is None:
         axis = []
         for i, s in enumerate(func.inputs[0].shape):
@@ -261,24 +262,24 @@ def convert_Squeeze(func, opset_version, input_names,
     else:
         axis = func.axis
 
-    return onnx_helper.make_node(
-        'Squeeze', input_names, num_outputs,
+    return onnx.helper.make_node(
+        'Squeeze', input_names, output_names,
         axes=axis
     ),
 
 
 def convert_Swapaxes(func, opset_version, input_names,
-                     num_outputs, context, parameters):
+                     output_names, context, parameters):
     perm = list(range(len(func.inputs[0].shape)))
     perm[func.axis1], perm[func.axis2] = perm[func.axis2], perm[func.axis1]
 
-    return onnx_helper.make_node(
-        'Transpose', input_names, num_outputs, perm=perm
+    return onnx.helper.make_node(
+        'Transpose', input_names, output_names, perm=perm
     ),
 
 
 @support((1, 6))
-def convert_Tile(func, opset_version, input_names, num_outputs,
+def convert_Tile(func, opset_version, input_names, output_names,
                  context, parameters):
     # Add tiles and axis to graph
     if isinstance(func.reps, int):
@@ -296,17 +297,17 @@ def convert_Tile(func, opset_version, input_names, num_outputs,
         parameters.append(axis_param)
         input_names.append(context.get_name(axis_param))
 
-    return onnx_helper.make_node('Tile', input_names, num_outputs),
+    return onnx.helper.make_node('Tile', input_names, output_names),
 
 
 def convert_Transpose(func, opset_version, input_names,
-                      num_outputs, context, parameters):
+                      output_names, context, parameters):
 
     if func.axes is None:
-        node = onnx_helper.make_node('Transpose', input_names, num_outputs)
+        node = onnx.helper.make_node('Transpose', input_names, output_names)
     else:
-        node = onnx_helper.make_node(
-            'Transpose', input_names, num_outputs,
+        node = onnx.helper.make_node(
+            'Transpose', input_names, output_names,
             perm=func.axes
         )
 
@@ -314,24 +315,24 @@ def convert_Transpose(func, opset_version, input_names,
 
 
 def convert_ExpandDims(func, opset_version, input_names,
-                       num_outputs, context, parameters):
+                       output_names, context, parameters):
     axis = func.axis
     if axis < 0:
         axis = len(func.inputs[0].shape) + 1 + axis
 
-    return onnx_helper.make_node(
-        'Unsqueeze', input_names, num_outputs, axes=[axis]),
+    return onnx.helper.make_node(
+        'Unsqueeze', input_names, output_names, axes=[axis]),
 
 
 @support((9,))
-def convert_Where(func, opset_version, input_names, num_outputs, context,
+def convert_Where(func, opset_version, input_names, output_names, context,
                   parameters):
     input_names.insert(0, context.get_name(func.condition))
-    return onnx_helper.make_node('Where', input_names, num_outputs),
+    return onnx.helper.make_node('Where', input_names, output_names),
 
 
 @support((7, 9))
-def convert_Repeat(func, opset_version, input_names, num_outputs, context,
+def convert_Repeat(func, opset_version, input_names, output_names, context,
                    parameters):
     repeats = func.repeats
     if len(repeats) > 1:
@@ -353,7 +354,7 @@ def convert_Repeat(func, opset_version, input_names, num_outputs, context,
 
     if opset_version == 7:
         gb.op('Upsample', inputs, scales=scales)
-        return gb.nodes()
+        return gb.nodes(output_names=output_names)
 
     if opset_version == 9:
         scales = np.array(scales, dtype=np.float32)
@@ -361,13 +362,13 @@ def convert_Repeat(func, opset_version, input_names, num_outputs, context,
         parameters.append(scales_param)
         inputs.append(context.get_name(scales_param))
         gb.op('Upsample', inputs)
-        return gb.nodes()
+        return gb.nodes(output_names=output_names)
 
 
 # NOTE(syoyo): `Upsampling` is deprecated in ONNX opset 10.
 # Use `Reshape` for opset 10
 @support((7, 9))
-def convert_ResizeImages(func, opset_version, input_names, num_outputs,
+def convert_ResizeImages(func, opset_version, input_names, output_names,
                          context, parameters):
 
     warnings.warn(
@@ -397,7 +398,7 @@ def convert_ResizeImages(func, opset_version, input_names, num_outputs,
     # Actually this will be mapped to 'bilinear' in onnxruntime
     mode = 'linear'
     if opset_version == 7:
-        return onnx_helper.make_node('Upsample', input_names, num_outputs,
+        return onnx.helper.make_node('Upsample', input_names, output_names,
                                      scales=scales, mode=mode),
 
     if opset_version == 9:
@@ -405,11 +406,11 @@ def convert_ResizeImages(func, opset_version, input_names, num_outputs,
         scales_param = chainer.Parameter(scales)
         parameters.append(scales_param)
         input_names.append(context.get_name(scales_param))
-        return onnx_helper.make_node('Upsample', input_names, num_outputs,
+        return onnx.helper.make_node('Upsample', input_names, output_names,
                                      mode=mode),
 
 
-def convert_Stack(func, opset_version, input_names, num_outputs, context,
+def convert_Stack(func, opset_version, input_names, output_names, context,
                   parameters):
     gb = onnx_helper.GraphBuilder()
     axis = func.axis
@@ -419,10 +420,10 @@ def convert_Stack(func, opset_version, input_names, num_outputs, context,
     # To use concat op, reshape every inputs add new axes
     inputs = [gb.op('Unsqueeze', [name], axes=[axis]) for name in input_names]
     gb.op('Concat', inputs, axis=axis)
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)
 
 
-def convert_Hstack(func, opset_version, input_names, num_outputs, context,
+def convert_Hstack(func, opset_version, input_names, output_names, context,
                    parameters):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
@@ -434,10 +435,10 @@ def convert_Hstack(func, opset_version, input_names, num_outputs, context,
     elif input0_ndim == 1:
         axis = 0
     gb.op('Concat', inputs, axis=axis)
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)
 
 
-def convert_Vstack(func, opset_version, input_names, num_outputs, context,
+def convert_Vstack(func, opset_version, input_names, output_names, context,
                    parameters):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
@@ -448,10 +449,10 @@ def convert_Vstack(func, opset_version, input_names, num_outputs, context,
     elif input0_ndim == 1:
         inputs = [gb.op('Unsqueeze', [name], axes=[0]) for name in input_names]
     gb.op('Concat', inputs, axis=0)
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)
 
 
-def convert_Dstack(func, opset_version, input_names, num_outputs, context,
+def convert_Dstack(func, opset_version, input_names, output_names, context,
                    parameters):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
@@ -465,4 +466,4 @@ def convert_Dstack(func, opset_version, input_names, num_outputs, context,
     elif input0_ndim == 2:
         inputs = [gb.op('Unsqueeze', [name], axes=[2]) for name in input_names]
     gb.op('Concat', inputs, axis=2)
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)

--- a/onnx_chainer/functions/converter.py
+++ b/onnx_chainer/functions/converter.py
@@ -47,8 +47,9 @@ class FunctionConverter(object):
         func = params.func
         opset_version = params.opset_version
         input_names = params.input_names
-        num_outputs = len(params.output_names)
+        output_names = params.output_names
         context = params.context
         parameters = params.parameters
         return self.converter(
-            func, opset_version, input_names, num_outputs, context, parameters)
+            func, opset_version, input_names, output_names, context,
+            parameters)

--- a/onnx_chainer/functions/loss.py
+++ b/onnx_chainer/functions/loss.py
@@ -8,7 +8,7 @@ from onnx_chainer import onnx_helper
 @support((9,))
 def convert_SoftmaxCrossEntropy(
         func, opset_version, input_names,
-        num_outputs, context, parameters):
+        output_names, context, parameters):
     # obtain input variable
     if not isinstance(func, chainer.FunctionNode):
         raise NotImplementedError(
@@ -41,4 +41,4 @@ def convert_SoftmaxCrossEntropy(
     sr = gb.op('ReduceSum', [sn], axes=[1], keepdims=0)
     gb.op('ReduceMean', [sr], axes=[0], keepdims=0)
 
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)

--- a/onnx_chainer/functions/loss.py
+++ b/onnx_chainer/functions/loss.py
@@ -39,6 +39,6 @@ def convert_SoftmaxCrossEntropy(
     s0 = gb.op('Mul', [y_log, th])
     sn = gb.op('Neg', [s0])
     sr = gb.op('ReduceSum', [sn], axes=[1], keepdims=0)
-    gb.op('ReduceMean', [sr], axes=[0], keepdims=0)
+    gb.op_output_named('ReduceMean', [sr], output_names, axes=[0], keepdims=0)
 
-    return gb.nodes(output_names=output_names)
+    return gb.nodes()

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -1,148 +1,149 @@
 import chainer
 import numpy as np
+import onnx
 
 from onnx_chainer.functions.opset_version import support
 from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
-def convert_Add(func, opset_version, input_names, num_outputs,
+def convert_Add(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Add', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Add', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Add', input_names, num_outputs),
+        return onnx.helper.make_node('Add', input_names, output_names),
 
 
 @support((1, 6, 7))
 def convert_AddConstant(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(context.get_name(value_param))
 
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Add', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Add', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Add', input_names, num_outputs),
+        return onnx.helper.make_node('Add', input_names, output_names),
 
 
 @support((1, 6, 7))
-def convert_Sub(func, opset_version, input_names, num_outputs,
+def convert_Sub(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Sub', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Sub', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Sub', input_names, num_outputs),
+        return onnx.helper.make_node('Sub', input_names, output_names),
 
 
 @support((1, 6, 7))
-def convert_Mul(func, opset_version, input_names, num_outputs,
+def convert_Mul(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Mul', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Mul', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Mul', input_names, num_outputs),
+        return onnx.helper.make_node('Mul', input_names, output_names),
 
 
 @support((1, 6, 7))
 def convert_MulConstant(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(context.get_name(value_param))
 
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Mul', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Mul', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Mul', input_names, num_outputs),
+        return onnx.helper.make_node('Mul', input_names, output_names),
 
 
 @support((1, 6))
-def convert_Neg(func, opset_version, input_names, num_outputs,
+def convert_Neg(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Neg', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Neg', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Neg', input_names, num_outputs),
+        return onnx.helper.make_node('Neg', input_names, output_names),
 
 
 @support((1, 6, 7))
-def convert_Div(func, opset_version, input_names, num_outputs,
+def convert_Div(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Div', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Div', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node('Div', input_names, num_outputs),
+        return onnx.helper.make_node('Div', input_names, output_names),
 
 
 @support((1, 6))
 def convert_Absolute(func, opset_version, input_names,
-                     num_outputs, context, parameters):
+                     output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Abs', input_names, num_outputs, consumed_inputs=[1]),
+        return onnx.helper.make_node(
+            'Abs', input_names, output_names, consumed_inputs=[1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Abs', input_names, num_outputs),
+        return onnx.helper.make_node('Abs', input_names, output_names),
 
 
 @support((1, 7))
 def convert_PowVarConst(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     value = np.array(func.value, dtype=func.inputs[0].dtype)
     value_param = chainer.Parameter(value)
     parameters.append(value_param)
     input_names.append(context.get_name(value_param))
 
     if opset_version == 1 or opset_version == 7:
-        return onnx_helper.make_node('Pow', input_names, num_outputs),
+        return onnx.helper.make_node('Pow', input_names, output_names),
 
 
 @support((1, 6))
-def convert_Clip(func, opset_version, input_names, num_outputs,
+def convert_Clip(func, opset_version, input_names, output_names,
                  context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Clip', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Clip', input_names, output_names,
             max=func.x_max,
             min=func.x_min,
             consumed_inputs=[1]
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'Clip', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Clip', input_names, output_names,
             max=func.x_max,
             min=func.x_min,
         ),
 
 
 @support((1, 6))
-def convert_Exp(func, opset_version, input_names, num_outputs,
+def convert_Exp(func, opset_version, input_names, output_names,
                 context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Exp', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Exp', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Exp', input_names, num_outputs),
+        return onnx.helper.make_node('Exp', input_names, output_names),
 
 
 def convert_Identity(func, opset_version, input_names,
-                     num_outputs, context, parameters):
-    return onnx_helper.make_node('Identity', input_names, num_outputs),
+                     output_names, context, parameters):
+    return onnx.helper.make_node('Identity', input_names, output_names),
 
 
 @support((1, 6, 7))
 def convert_MatMul(func, opset_version, input_names,
-                   num_outputs, context, parameters):
+                   output_names, context, parameters):
     bias_shape = (
         func.inputs[0].shape[-1] if func.transa else func.inputs[0].shape[-2],
         func.inputs[1].shape[-2] if func.transb else func.inputs[1].shape[-1]
@@ -152,8 +153,8 @@ def convert_MatMul(func, opset_version, input_names,
     parameters.append(bias_param)
     input_names.append(context.get_name(bias_param))
 
-    return onnx_helper.make_node(
-        'Gemm', input_names, num_outputs,
+    return onnx.helper.make_node(
+        'Gemm', input_names, output_names,
         transA=func.transa,
         transB=func.transb
     ),
@@ -161,36 +162,36 @@ def convert_MatMul(func, opset_version, input_names,
 
 @support((1, 6, 8))
 def convert_Maximum(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Max', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Max', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 8:
-        return onnx_helper.make_node('Max', input_names, num_outputs),
+        return onnx.helper.make_node('Max', input_names, output_names),
 
 
 @support((1, 6, 8))
 def convert_Minimum(func, opset_version, input_names,
-                    num_outputs, context, parameters):
+                    output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Min', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Min', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 8:
-        return onnx_helper.make_node('Min', input_names, num_outputs),
+        return onnx.helper.make_node('Min', input_names, output_names),
 
 
 @support((1, 6))
-def convert_Sqrt(func, opset_version, input_names, num_outputs,
+def convert_Sqrt(func, opset_version, input_names, output_names,
                  context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Sqrt', input_names, num_outputs, consumed_inputs=[1, 1]),
+        return onnx.helper.make_node(
+            'Sqrt', input_names, output_names, consumed_inputs=[1, 1]),
     elif opset_version == 6:
-        return onnx_helper.make_node('Sqrt', input_names, num_outputs),
+        return onnx.helper.make_node('Sqrt', input_names, output_names),
 
 
 def convert_LogSumExp(func, opset_version, input_names,
-                      num_outputs, context, parameters):
+                      output_names, context, parameters):
     # Use keepdims=False by default
     # since the chainer does not support keepdims option
     kwargs = {'keepdims': False}
@@ -198,58 +199,58 @@ def convert_LogSumExp(func, opset_version, input_names,
         kwargs['keepdims'] = func.keepdims
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceLogSumExp', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceLogSumExp', input_names, output_names, **kwargs),
 
 
-def convert_Max(func, opset_version, input_names, num_outputs,
+def convert_Max(func, opset_version, input_names, output_names,
                 context, parameters):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceMax', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceMax', input_names, output_names, **kwargs),
 
 
-def convert_Mean(func, opset_version, input_names, num_outputs,
+def convert_Mean(func, opset_version, input_names, output_names,
                  context, parameters):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceMean', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceMean', input_names, output_names, **kwargs),
 
 
-def convert_Min(func, opset_version, input_names, num_outputs,
+def convert_Min(func, opset_version, input_names, output_names,
                 context, parameters):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceMin', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceMin', input_names, output_names, **kwargs),
 
 
-def convert_Prod(func, opset_version, input_names, num_outputs,
+def convert_Prod(func, opset_version, input_names, output_names,
                  context, parameters):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceProd', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceProd', input_names, output_names, **kwargs),
 
 
-def convert_Sum(func, opset_version, input_names, num_outputs,
+def convert_Sum(func, opset_version, input_names, output_names,
                 context, parameters):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
-    return onnx_helper.make_node(
-        'ReduceSum', input_names, num_outputs, **kwargs),
+    return onnx.helper.make_node(
+        'ReduceSum', input_names, output_names, **kwargs),
 
 
 @support((1, 6, 7))
 def convert_LinearInterpolate(func, opset_version, input_names,
-                              num_outputs, context, parameters):
+                              output_names, context, parameters):
     typ = func.inputs[0].dtype if isinstance(
         func.inputs[0].dtype, np.dtype) else np.dtype(func.inputs[0].dtype)
 
@@ -264,27 +265,27 @@ def convert_LinearInterpolate(func, opset_version, input_names,
     n1 = gb.op('Sub', [context.get_name(one), p], **kwargs, **kwargs2)
     n2 = gb.op('Mul', [p, x], **kwargs)
     n3 = gb.op('Mul', [n1, y], **kwargs)
-    gb.op('Add', [n2, n3], num_outputs, **kwargs)
+    gb.op('Add', [n2, n3], **kwargs)
 
-    return gb.nodes()
+    return gb.nodes(output_names=output_names)
 
 
 @support((1, 6, 7))
 def convert_Square(func, opset_version, input_names,
-                   num_outputs, context, parameters):
+                   output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Mul', [input_names[0], input_names[0]], num_outputs,
+        return onnx.helper.make_node(
+            'Mul', [input_names[0], input_names[0]], output_names,
             consumed_inputs=[1, 1]),
     elif opset_version == 6 or opset_version == 7:
-        return onnx_helper.make_node(
-            'Mul', [input_names[0], input_names[0]], num_outputs),
+        return onnx.helper.make_node(
+            'Mul', [input_names[0], input_names[0]], output_names),
 
 
 @support((8,))
 def convert_BroadcastTo(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     shape = np.array(func._shape)
     parameters.append(shape)
     input_names.append(context.get_name(shape))
-    return onnx_helper.make_node('Expand', input_names, num_outputs),
+    return onnx.helper.make_node('Expand', input_names, output_names),

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -265,9 +265,9 @@ def convert_LinearInterpolate(func, opset_version, input_names,
     n1 = gb.op('Sub', [context.get_name(one), p], **kwargs, **kwargs2)
     n2 = gb.op('Mul', [p, x], **kwargs)
     n3 = gb.op('Mul', [n1, y], **kwargs)
-    gb.op('Add', [n2, n3], **kwargs)
+    gb.op_output_named('Add', [n2, n3], output_names, **kwargs)
 
-    return gb.nodes(output_names=output_names)
+    return gb.nodes()
 
 
 @support((1, 6, 7))

--- a/onnx_chainer/functions/noise.py
+++ b/onnx_chainer/functions/noise.py
@@ -1,28 +1,28 @@
 import chainer
+import onnx
 
 from onnx_chainer.functions.opset_version import support
-from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
 def convert_Dropout(
         func, opset_version, input_names,
-        num_outputs, context, parameters):
+        output_names, context, parameters):
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'Dropout', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Dropout', input_names, output_names,
             is_test=0 if chainer.config.train else 1,
             ratio=func.dropout_ratio,
             consumed_inputs=[1]
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'Dropout', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Dropout', input_names, output_names,
             is_test=0 if chainer.config.train else 1,
             ratio=func.dropout_ratio,
         ),
     elif opset_version == 7:
-        return onnx_helper.make_node(
-            'Dropout', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'Dropout', input_names, output_names,
             ratio=func.dropout_ratio,
         ),

--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -2,14 +2,14 @@ import sys
 
 import chainer
 import numpy as np
+import onnx
 
 from onnx_chainer.functions.opset_version import support
-from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
 def convert_BatchNormalization(func, opset_version, input_names,
-                               num_outputs, context, parameters):
+                               output_names, context, parameters):
     if len(func.inputs) <= 3:
         # expect this `func` is F.batch_normalization
         x = func.inputs[0].get_variable().array
@@ -44,23 +44,23 @@ def convert_BatchNormalization(func, opset_version, input_names,
     # must make 5 values for output and return them.
 
     if opset_version == 1:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'BatchNormalization', input_names, output_names,
             epsilon=func.eps,
             momentum=momentum,
             is_test=not chainer.config.train,
             consumed_inputs=[False, False, False, True, True],
         ),
     elif opset_version == 6:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'BatchNormalization', input_names, output_names,
             epsilon=func.eps,
             momentum=momentum,
             is_test=not chainer.config.train,
         ),
     elif opset_version == 7:
-        return onnx_helper.make_node(
-            'BatchNormalization', input_names, num_outputs,
+        return onnx.helper.make_node(
+            'BatchNormalization', input_names, output_names,
             epsilon=func.eps,
             momentum=momentum,
         ),
@@ -68,18 +68,18 @@ def convert_BatchNormalization(func, opset_version, input_names,
 
 @support((1, 6, 7))
 def convert_FixedBatchNormalization(func, opset_version,
-                                    input_names, num_outputs, context,
+                                    input_names, output_names, context,
                                     parameters):
     return convert_BatchNormalization(
-        func, opset_version, input_names, num_outputs, context, parameters)
+        func, opset_version, input_names, output_names, context, parameters)
 
 
 def convert_LocalResponseNormalization(func, opset_version,
-                                       input_names, num_outputs, context,
+                                       input_names, output_names, context,
                                        parameters):
     size = int(func.n)
-    return onnx_helper.make_node(
-        'LRN', input_names, num_outputs,
+    return onnx.helper.make_node(
+        'LRN', input_names, output_names,
         alpha=float(func.alpha) * size,
         beta=float(func.beta),
         bias=float(func.k),
@@ -88,7 +88,7 @@ def convert_LocalResponseNormalization(func, opset_version,
 
 
 def convert_NormalizeL2(func, opset_version, input_names,
-                        num_outputs, context, parameters):
+                        output_names, context, parameters):
     if isinstance(func.axis, tuple) and len(func.axis) != 1:
         raise ValueError(
             'Normalization along with multiple axes ({}) are not supported in '
@@ -100,8 +100,8 @@ def convert_NormalizeL2(func, opset_version, input_names,
             ' so that ONNX-Chainer does not accept custom values for \'eps\' '
             '({})'.format(func.eps))
 
-    return onnx_helper.make_node(
-        'LpNormalization', input_names, num_outputs,
+    return onnx.helper.make_node(
+        'LpNormalization', input_names, output_names,
         axis=int(func.axis[0]),
         p=2,
     ),

--- a/onnx_chainer/graph.py
+++ b/onnx_chainer/graph.py
@@ -71,10 +71,7 @@ class Graph(object):
             func, self.specified_opset_version, input_names, output_names,
             self.context, parameters)
         nodes = converter(params)
-        nodes = list(reversed(nodes))
-        assert len(nodes[0].output) == len(output_names)
-        nodes[0].output[:] = output_names
-        return nodes
+        return list(reversed(nodes))
 
     def convert_to_onnx_node(self, function):
         if isinstance(function, chainer.function.FunctionAdapter):

--- a/onnx_chainer/onnx_helper.py
+++ b/onnx_chainer/onnx_helper.py
@@ -88,13 +88,16 @@ class GraphBuilder(object):
         tensor = onnx.numpy_helper.from_array(array)
         return self.op('Constant', [], 1, value=tensor)
 
-    def nodes(self):
+    def nodes(self, output_names=None):
         """Returns all nodes created so far.
 
         Returns:
           A list of `onnx.NodeProto` objects, suitable as the return
           value of converter functions.
         """
+        if output_names is not None:
+            assert len(self._nodes[-1].output) == len(output_names)
+            self._nodes[-1].output[:] = output_names
         return tuple(self._nodes)
 
 

--- a/tests/test_external_converter.py
+++ b/tests/test_external_converter.py
@@ -19,8 +19,8 @@ def test_export_external_converters_overwrite(tmpdir):
     x = input_generator.positive_increasing(2, 5)
 
     def custom_converter(params):
-        return onnx_helper.make_node(
-            'Tanh', params.input_names, len(params.output_names)),
+        return onnx.helper.make_node(
+            'Tanh', params.input_names, params.output_names),
 
     addon_converters = {'Sigmoid': custom_converter}
     with warnings.catch_warnings(record=True) as w:
@@ -54,9 +54,8 @@ def test_export_external_converters_custom_op(tmpdir, domain, version):
     x = input_generator.increasing(2, 5)
 
     def custom_converter(params):
-        return onnx_helper.make_node(
-            'Dummy', params.input_names, len(params.output_names),
-            domain=domain),
+        return onnx.helper.make_node(
+            'Dummy', params.input_names, params.output_names, domain=domain),
 
     addon_converters = {'Dummy': custom_converter}
 

--- a/tests/test_replace_func.py
+++ b/tests/test_replace_func.py
@@ -62,7 +62,7 @@ class TestReplaceNumpyFullToConstantOfShape(ONNXModelTest):
             value = onnx.helper.make_tensor(
                 'value', onnx.TensorProto.FLOAT, [1], [params.func.value])
             gb.op('ConstantOfShape', [output], value=value)
-            return gb.nodes()
+            return gb.nodes(output_names=params.output_names)
 
         addon_converters = {'NumpyFull': numpy_full_converter}
 
@@ -179,8 +179,8 @@ def test_replace_func_collection_return(tmpdir, return_type):
         model.tiled_array = fake_as_funcnode(model.tiled_array, 'xTiledArray')
 
     def tiled_array_converter(params):
-        return onnx_helper.make_node(
-            'xTiledArray', params.input_names, len(params.output_names)),
+        return onnx.helper.make_node(
+            'xTiledArray', params.input_names, params.output_names),
 
     addon_converters = {'xTiledArray': tiled_array_converter}
 

--- a/tests/test_replace_func.py
+++ b/tests/test_replace_func.py
@@ -61,8 +61,9 @@ class TestReplaceNumpyFullToConstantOfShape(ONNXModelTest):
             output = gb.op('Shape', params.input_names)
             value = onnx.helper.make_tensor(
                 'value', onnx.TensorProto.FLOAT, [1], [params.func.value])
-            gb.op('ConstantOfShape', [output], value=value)
-            return gb.nodes(output_names=params.output_names)
+            gb.op_output_named(
+                'ConstantOfShape', [output], params.output_names, value=value)
+            return gb.nodes()
 
         addon_converters = {'NumpyFull': numpy_full_converter}
 


### PR DESCRIPTION
Current ONNX-chainer cannot handle the blow converter.
```
   ┌- B -- B'
A -┤
   └- C -- C'
```

Because `output_names` must be set at each `B'` and `C'`, but the `output_name` force to set out of converter https://github.com/chainer/onnx-chainer/blob/e7c2e4e13463fa981e9739454f880cb3e4997ecd/onnx_chainer/graph.py#L76

For example, Chainer's `Separate` function can be represented as `Split` + `Squeeze`, but converter cannot set `output_names` at each output from `Squeeze`. This PR is to support it.