### PR TITLE
Fix pad converter with scalar pad width

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -143,7 +143,10 @@ def convert_Pad(func, opset_version, input_names, output_names,
 
     pad_begin = []
     pad_end = []
-    for pp in func.pad_bw.tolist():
+    pad_bw = func.pad_bw
+    if pad_bw.ndim == 1:
+        pad_bw = np.tile(pad_bw, (len(func.inputs[0].shape), 1))
+    for pp in pad_bw.tolist():
         pad_begin.append(pp[0])
         pad_end.append(pp[1])
     pad = pad_begin + pad_end

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -50,6 +50,11 @@ from tests.helper import ONNXModelTest
               'mode': 'constant',
               'constant_values': -1},
      'name': 'pad_with_constant_values'},
+    {'ops': 'pad', 'input_shape': (1, 2, 3, 4),
+     'input_argname': 'x',
+     'args': {'pad_width': 2,
+              'mode': 'constant'},
+     'name': 'pad_scalar_pad_width'},
 
     # reshape
     {'ops': 'reshape', 'input_shape': (1, 6),


### PR DESCRIPTION
This is a regression caused by #162. Because now we do not
run `backward`, `Pad.pad_bw` is not canonicalized.

https://github.com/chainer/chainer/blob/master/chainer/functions/array/pad.py#L36