### PR TITLE
Handle ONNX format checker both 1.4.1 and 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       python: "3.5"
       env:
         - CHAINER_INSTALL="--pre"
-    - name: "Py36, Chainer pre-rlease"
+    - name: "Py36, Chainer pre-release"
       python: "3.6"
       env:
         - CHAINER_INSTALL="--pre"

--- a/onnx_chainer/onnx_helper.py
+++ b/onnx_chainer/onnx_helper.py
@@ -1,4 +1,5 @@
 import onnx
+from packaging import version
 
 
 __func_name = None  # not care the name is unique on whole graph
@@ -140,3 +141,9 @@ def cleanse_param_name(name):
       A valid ONNX name (e.g., param_l_W).
     """
     return 'param' + name.replace('/', '_')
+
+
+def is_support_non_standard_domain():
+    # from ONNX 1.5, skip schema check on ops in non-standard domain
+    # see: https://github.com/onnx/onnx/pull/1876
+    return version.parse(onnx.__version__) >= version.parse('1.5')

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = {
     'travis': [
         '-r stylecheck',
         '-r test-cpu',
+        'packaging>=19.0',
         'pytest-cov',
         'codecov',
     ],


### PR DESCRIPTION
ONNX-Chainer accepts insufficient format when domain is not set, to make development easier, but show warnings. fixes #180 