### PR TITLE
[WIP] Add option to handle dynamic shape on reshape node

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -335,7 +335,7 @@ def _export(model, args, filename, export_params, graph_name, save_text,
     model.ir_version = onnx.IR_VERSION
 
     try:
-        print('checker.check_model(model)')
+        checker.check_model(model)
     except onnx.checker.ValidationError as e:
         if external_converters is None:
             raise e

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -335,7 +335,7 @@ def _export(model, args, filename, export_params, graph_name, save_text,
     model.ir_version = onnx.IR_VERSION
 
     try:
-        checker.check_model(model)
+        print('checker.check_model(model)')
     except onnx.checker.ValidationError as e:
         if external_converters is None:
             raise e

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -211,7 +211,7 @@ def _export(model, args, filename, export_params, graph_name, save_text,
                 m=MINIMUM_OPSET_VERSION,
                 o=opset_version)
         )
-
+    import onnx_chainer.variable
     # Forward computation
     context = Context(model)
     network_inputs = OrderedDict()

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -111,8 +111,8 @@ def rename_variable_name(
 def export(model, args, filename=None, export_params=True,
            graph_name='Graph', save_text=False, opset_version=None,
            input_names=None, output_names=None, train=False,
-           return_named_inout=False, external_converters=None,
-           external_opset_imports=None):
+           return_named_inout=False, input_shape=None,
+           external_converters=None, external_opset_imports=None):
     """Export function for chainer.Chain in ONNX format.
 
     This function performs a forward computation of the given
@@ -172,6 +172,7 @@ def export(model, args, filename=None, export_params=True,
         train (bool): If True, output computational graph with train mode.
         return_named_inout (bool): If set True, return ONNX model with named
             inputs, and named outputs.
+        input_shape (tuple): Customized input shape, not take from ``args``.
         external_converters (dict): Add-on converter. Convert functions
             keyed by ~chainer.FunctionNode name.
         external_opset_imports (dict): Import external opset. opset version
@@ -193,12 +194,12 @@ def export(model, args, filename=None, export_params=True,
         return _export(
             model, args, filename, export_params, graph_name, save_text,
             opset_version, input_names, output_names, return_named_inout,
-            external_converters, external_opset_imports)
+            input_shape, external_converters, external_opset_imports)
 
 
 def _export(model, args, filename, export_params, graph_name, save_text,
             opset_version, input_names, output_names, return_named_inout,
-            external_converters, external_opset_imports):
+            input_shape, external_converters, external_opset_imports):
     if opset_version is None:
         opset_version = int(onnx.defs.onnx_opset_version())
     elif opset_version < MINIMUM_OPSET_VERSION:
@@ -211,7 +212,12 @@ def _export(model, args, filename, export_params, graph_name, save_text,
                 m=MINIMUM_OPSET_VERSION,
                 o=opset_version)
         )
-    import onnx_chainer.variable
+
+    if input_shape is not None and \
+            any([isinstance(s, str) for s in input_shape]):
+        from onnx_chainer.variable import enable_shape_variable
+        enable_shape_variable(input_shape)
+
     # Forward computation
     context = Context(model)
     network_inputs = OrderedDict()

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -262,8 +262,9 @@ def _export(model, args, filename, export_params, graph_name, save_text,
             name, tensor.data_type, tensor.dims))
 
     for name, var in network_inputs.items():
+        shape = [int(s) for s in var.shape]
         input_tensors.append(helper.make_tensor_value_info(
-            name, NP_TYPE_TO_TENSOR_TYPE[var.dtype], var.shape))
+            name, NP_TYPE_TO_TENSOR_TYPE[var.dtype], shape))
 
     if external_converters:
         chainer.utils.experimental('external_converters')
@@ -308,8 +309,9 @@ def _export(model, args, filename, export_params, graph_name, save_text,
     # Convert output tensors
     output_tensors = []
     for name, var in network_outputs.items():
+        shape = [int(s) for s in var.shape]
         output_tensors.append(helper.make_tensor_value_info(
-            name, NP_TYPE_TO_TENSOR_TYPE[var.dtype], var.shape))
+            name, NP_TYPE_TO_TENSOR_TYPE[var.dtype], shape))
 
     if not export_params:
         initializers = []

--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -22,8 +22,8 @@ from onnx_chainer.functions.array import convert_Pad  # NOQA
 from onnx_chainer.functions.array import convert_Repeat  # NOQA
 from onnx_chainer.functions.array import convert_Reshape  # NOQA
 from onnx_chainer.functions.array import convert_ResizeImages  # NOQA
-from onnx_chainer.functions.array import convert_Shape  # NOQA
 from onnx_chainer.functions.array import convert_Separate  # NOQA
+from onnx_chainer.functions.array import convert_Shape  # NOQA
 from onnx_chainer.functions.array import convert_Space2Depth  # NOQA
 from onnx_chainer.functions.array import convert_SplitAxis  # NOQA
 from onnx_chainer.functions.array import convert_Squeeze  # NOQA

--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -22,6 +22,7 @@ from onnx_chainer.functions.array import convert_Pad  # NOQA
 from onnx_chainer.functions.array import convert_Repeat  # NOQA
 from onnx_chainer.functions.array import convert_Reshape  # NOQA
 from onnx_chainer.functions.array import convert_ResizeImages  # NOQA
+from onnx_chainer.functions.array import convert_Shape  # NOQA
 from onnx_chainer.functions.array import convert_Separate  # NOQA
 from onnx_chainer.functions.array import convert_Space2Depth  # NOQA
 from onnx_chainer.functions.array import convert_SplitAxis  # NOQA

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -211,9 +211,14 @@ def convert_Reshape(func, opset_version, input_names,
             shape=func.shape
         ),
     elif opset_version == 5:
-        shape_name = context.add_param(
-            np.asarray(list(func.shape), dtype=np.int64), 'shape')
-        input_names.append(shape_name)
+        if hasattr(func, 'shape'):
+            assert len(input_names) == 1
+            shape_name = context.add_param(
+                np.asarray(list(func.shape), dtype=np.int64), 'shape')
+            input_names.append(shape_name)
+        else:
+            if len(input_names) != 2:
+                raise ValueError('shape must be set as parameter or 2nd input')
 
         return onnx_helper.make_node(
             'Reshape', input_names, output_names,
@@ -481,3 +486,8 @@ def convert_Separate(func, opset_version, input_names, output_names, context,
         gb.op_output_named(
             'Squeeze', [node_name], [output_names[i]], axes=[func.axis])
     return gb.nodes()
+
+
+def convert_Shape(func, opset_version, input_names, output_names, context,
+                  parameters):
+    return onnx_helper.make_node('Shape', input_names, output_names),

--- a/onnx_chainer/functions/connection.py
+++ b/onnx_chainer/functions/connection.py
@@ -116,3 +116,31 @@ def convert_LinearFunction(func, opset_version, input_names,
         return onnx_helper.make_node(
             'Gemm', input_names, output_names,
             alpha=1.0, beta=1.0, transA=0, transB=1),
+
+
+@support((10,))
+def convert_DynamicBatchReshapeLinear(func, opset_version, input_names,
+                                      output_names, context, parameters):
+    ndim = len(func.inputs[0].shape)
+    if ndim <= 2:
+        return convert_LinearFunction(func, opset_version, input_names, output_names, context, parameters)
+
+    gb = onnx_helper.GraphBuilder()
+    shape = gb.op('Shape', [input_names[0]])
+    axes = [0]
+    starts = [0]
+    ends = [1]
+    slice_inputs = [shape]
+    for param in [('starts', starts), ('ends', ends), ('axes', axes)]:
+        pname = context.add_param(np.asarray(list(param[1]), dtype=np.int64), param[0])
+        slice_inputs.append(pname)
+    shape0 = gb.op('Slice', slice_inputs)
+    # shape0_int = gb.op('Squeeze', [shape0], axes=[0])
+
+    neg1 = context.add_param(np.asarray([-1], dtype=np.int64), 'reshaped_arg1')
+    reshape_arg = gb.op('Concat', [shape0, neg1], axis=0)
+
+    reshaped_x = [gb.op('Reshape', [input_names[0], reshape_arg])]
+    reshaped_x.extend(input_names[1:])
+    linear_node = convert_LinearFunction(func, opset_version, reshaped_x, output_names, context, parameters)
+    return gb.nodes() + linear_node

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -29,6 +29,7 @@ _supported_function_node_set = {
     'Repeat',
     'Reshape',
     'ResizeImages',
+    'Shape',
     'Separate',
     'Space2Depth',
     'SplitAxis',

--- a/onnx_chainer/replace_func.py
+++ b/onnx_chainer/replace_func.py
@@ -145,6 +145,9 @@ def fake_as_funcnode(alt_func, name, rename_attributes=None):
         ret = wrapped.apply(inputs)
         if len(ret) > 1:
             return ret
+        if name == 'Shape':
+            from onnx_chainer.variable import ShapeVariable
+            return ShapeVariable.create(ret[0])
         return ret[0]
 
     chainer.utils.experimental('as_funcnode')

--- a/onnx_chainer/variable.py
+++ b/onnx_chainer/variable.py
@@ -9,7 +9,7 @@ from onnx_chainer.replace_func import as_funcnode
 @property
 @as_funcnode('Shape')
 def shape(self):
-    return self.xp.asarray(self.array.shape, dtype=np.float32)
+    return self.xp.asarray(self.array.shape, dtype=np.int64)
 
 
 def __mod__(self, other):
@@ -21,6 +21,7 @@ def __rmod__(self, other):
 
 
 def __rmul__(self, other):
+    print('asss')
     return other * self.array
 
 
@@ -74,12 +75,32 @@ global_xx = []
 
 
 chainer.Variable.shape = shape
-chainer.Variable.__mod__ = __mod__
-chainer.Variable.__rmod__ = __rmod__
-chainer.Variable.__rmul__ = __rmul__
-chainer.Variable.__int__ = __int__
-chainer.Variable.__eq__ = __eq__
-chainer.Variable.__ne__ = __ne__
-chainer.Variable.__lt__ = __lt__
-chainer.Variable.__gt__ = __gt__
+# chainer.Variable.__mod__ = __mod__
+# chainer.Variable.__rmod__ = __rmod__
+# chainer.Variable.__rmul__ = __rmul__
+# chainer.Variable.__int__ = __int__
+# chainer.Variable.__eq__ = __eq__
+# chainer.Variable.__ne__ = __ne__
+# chainer.Variable.__lt__ = __lt__
+# chainer.Variable.__gt__ = __gt__
 chainer.functions.reshape = reshape
+
+
+class ShapeVariable(chainer.Variable):
+    @staticmethod
+    def create(var):
+        target = ShapeVariable()
+        target.__dict__ = var.__dict__
+        target._node = var._node
+        return target
+
+    def __getitem__(self, item):
+        print('get')
+        if isinstance(item, int) and item != 0:
+            print('!!!!!!!!!!!!')
+            return super().__getitem__(item).array
+        return super().__getitem__(item)
+
+    def __iter__(self):
+        print('aaa')
+        return super()

--- a/onnx_chainer/variable.py
+++ b/onnx_chainer/variable.py
@@ -15,20 +15,21 @@ def shape(self):
     # return self.xp.asarray(super(BatchMarkedVariable, self).shape)
     return ShapeVariable(self.array.shape, 0)
 
-_reshape = chainer.Variable.reshape
+_reshape = chainer.functions.reshape
 
-def reshape(*shape):
-    self = shape[0]
-    shape = list(shape[1:])
+def reshape(x, shape):
     print('reshape', shape)
-    for i, s in enumerate(shape):
-        if isinstance(s, ShapeItemVariable):
-            print('danger!!')
-            shape[i] = int(s)
-    return _reshape(self, tuple(shape))
+    if isinstance(shape, tuple):
+        shape = list(shape)
+    if isinstance(shape, list):
+        for i, s in enumerate(shape):
+            if isinstance(s, ShapeItemVariable):
+                print('danger!!')
+                shape[i] = int(s)
+    return _reshape(x, shape)
 
 chainer.Variable.shape = shape
-chainer.Variable.reshape = reshape
+chainer.functions.reshape = reshape
 
 
 class ShapeVariable(object):
@@ -76,33 +77,18 @@ class ShapeVariable(object):
 
 
 class ShapeItemVariable(object):
+
+    # NOTE(disktnk): numbers.Integral is better, but select simple one
+
     def __init__(self, val=0):
+        assert isinstance(val, int)
         self._val = int(val)
-    def __add__(self, val):
-        if isinstance(val, Integer):
-            return Integer(self._val + val._val)
-        return self._val + val
-    def __iadd__(self, val):
-        self._val += val
-        return self
-    def __mul__(self, val):
-        print(';;;;;')
-        return self._val * val
-    def __imul__(self, val):
-        print(';;;;;')
-        self._val *= val
-        return self._val
-    def __str__(self):
-        return str(self._val)
-    def __repr__(self):
-        return 'Integer(%s)' % self._val
-    def __eq__(self, other):
-        return self._val == other
+
     def __int__(self):
         return self._val
 
     def __lt__(self, other):
         return self._val < other
 
-    def __gt__(self, other):
-        return self._val > other
+    def __rmul__(self, other):
+        return self._val * other

--- a/onnx_chainer/variable.py
+++ b/onnx_chainer/variable.py
@@ -1,94 +1,85 @@
 import chainer
+import chainer.functions as F
 import numpy as np
 
 from onnx_chainer import onnx_helper
 from onnx_chainer.replace_func import as_funcnode
 
 
-def convert_Shape(func, opset_version, input_names, output_names, context, parameters):
-    return onnx_helper.make_node(
-        'Shape', input_names, output_names)
-
-
 @property
+@as_funcnode('Shape')
 def shape(self):
-    # return self.xp.asarray(super(BatchMarkedVariable, self).shape)
-    return ShapeVariable(self.array.shape, 0)
+    return self.xp.asarray(self.array.shape, dtype=np.float32)
 
-_reshape = chainer.functions.reshape
+
+def __mod__(self, other):
+    return self.array % other
+
+
+def __rmod__(self, other):
+    return other % self.array
+
+
+def __rmul__(self, other):
+    return other * self.array
+
+
+def __int__(self):
+    assert len(self.array.shape) == 0
+    return int(self.array)
+
+
+def __eq__(self, other):
+    print(other)
+    print(self.array)
+    return self.array == other
+
+
+def __ne__(self, other):
+    return self.array != other
+
+
+def __gt__(self, other):
+    return self.array > other
+
+
+def __lt__(self, other):
+    return self.array < other
+
+
+org_reshape = chainer.functions.reshape
+
+
+@as_funcnode('Reshape')
+def dynamic_reshape(x, shape):
+    return x.array.reshape(shape.array.astype(np.int64))
+
 
 def reshape(x, shape):
-    print('reshape', shape)
-    if isinstance(shape, tuple):
-        shape = list(shape)
-    if isinstance(shape, list):
-        for i, s in enumerate(shape):
-            if isinstance(s, ShapeItemVariable):
-                print('danger!!')
-                shape[i] = int(s)
-    return _reshape(x, shape)
+    if any([isinstance(s, chainer.Variable) for s in shape]):
+        shape_list = []
+        for s in shape:
+            if isinstance(s, chainer.Variable):
+                shape_list.append(s)
+            else:
+                ss = chainer.Variable(np.array(s, dtype=np.float32))
+                global_xx.append(ss)
+                shape_list.append(ss)
+        shape = F.stack(shape_list)
+        return dynamic_reshape(x, shape)
+    return org_reshape(x, shape)
+
+
+global_xx = []
+
 
 chainer.Variable.shape = shape
+chainer.Variable.__mod__ = __mod__
+chainer.Variable.__rmod__ = __rmod__
+chainer.Variable.__rmul__ = __rmul__
+chainer.Variable.__int__ = __int__
+chainer.Variable.__eq__ = __eq__
+chainer.Variable.__ne__ = __ne__
+chainer.Variable.__lt__ = __lt__
+chainer.Variable.__gt__ = __gt__
 chainer.functions.reshape = reshape
-
-
-class ShapeVariable(object):
-
-    def __init__(self, shape, batch_idx=None):
-        print('shape_variable')
-        self.shape = shape
-        self.batch_idx = batch_idx
-
-    def __getitem__(self, i):
-        print('get_item', i, self.batch_idx)
-        if self.batch_idx is not None and i == self.batch_idx:
-            print('batched!!')
-            return ShapeItemVariable(self.shape[i])
-        return self.shape[i]
-
-    def __iter__(self):
-        print('iter')
-        for s in self.shape:
-            yield s
-
-    def __eq__(self, other):
-        return self.shape == other
-
-    def __lt__(self, other):
-        return self.shape < other
-
-    def __gt__(self, other):
-        return self.shape > other
-
-    def __mod__(self, other):
-        return self.shape % other
-
-    def __truediv__(self, other):
-        return self.shape / other
-
-    def __mul__(self, other):
-        return self.shape * other
-
-    def __imul__(self, other):
-        return self.shape * other
-
-    def __len__(self):
-        return len(self.shape)
-
-
-class ShapeItemVariable(object):
-
-    # NOTE(disktnk): numbers.Integral is better, but select simple one
-
-    def __init__(self, val=0):
-        assert isinstance(val, int)
-        self._val = int(val)
-
-    def __int__(self):
-        return self._val
-
-    def __lt__(self, other):
-        return self._val < other
-
-    def __rmul__(self, other):
-        return self._val * other

--- a/onnx_chainer/variable.py
+++ b/onnx_chainer/variable.py
@@ -1,0 +1,108 @@
+import chainer
+import numpy as np
+
+from onnx_chainer import onnx_helper
+from onnx_chainer.replace_func import as_funcnode
+
+
+def convert_Shape(func, opset_version, input_names, output_names, context, parameters):
+    return onnx_helper.make_node(
+        'Shape', input_names, output_names)
+
+
+@property
+def shape(self):
+    # return self.xp.asarray(super(BatchMarkedVariable, self).shape)
+    return ShapeVariable(self.array.shape, 0)
+
+_reshape = chainer.Variable.reshape
+
+def reshape(*shape):
+    self = shape[0]
+    shape = list(shape[1:])
+    print('reshape', shape)
+    for i, s in enumerate(shape):
+        if isinstance(s, ShapeItemVariable):
+            print('danger!!')
+            shape[i] = int(s)
+    return _reshape(self, tuple(shape))
+
+chainer.Variable.shape = shape
+chainer.Variable.reshape = reshape
+
+
+class ShapeVariable(object):
+
+    def __init__(self, shape, batch_idx=None):
+        print('shape_variable')
+        self.shape = shape
+        self.batch_idx = batch_idx
+
+    def __getitem__(self, i):
+        print('get_item', i, self.batch_idx)
+        if self.batch_idx is not None and i == self.batch_idx:
+            print('batched!!')
+            return ShapeItemVariable(self.shape[i])
+        return self.shape[i]
+
+    def __iter__(self):
+        print('iter')
+        for s in self.shape:
+            yield s
+
+    def __eq__(self, other):
+        return self.shape == other
+
+    def __lt__(self, other):
+        return self.shape < other
+
+    def __gt__(self, other):
+        return self.shape > other
+
+    def __mod__(self, other):
+        return self.shape % other
+
+    def __truediv__(self, other):
+        return self.shape / other
+
+    def __mul__(self, other):
+        return self.shape * other
+
+    def __imul__(self, other):
+        return self.shape * other
+
+    def __len__(self):
+        return len(self.shape)
+
+
+class ShapeItemVariable(object):
+    def __init__(self, val=0):
+        self._val = int(val)
+    def __add__(self, val):
+        if isinstance(val, Integer):
+            return Integer(self._val + val._val)
+        return self._val + val
+    def __iadd__(self, val):
+        self._val += val
+        return self
+    def __mul__(self, val):
+        print(';;;;;')
+        return self._val * val
+    def __imul__(self, val):
+        print(';;;;;')
+        self._val *= val
+        return self._val
+    def __str__(self):
+        return str(self._val)
+    def __repr__(self):
+        return 'Integer(%s)' % self._val
+    def __eq__(self, other):
+        return self._val == other
+    def __int__(self):
+        return self._val
+
+    def __lt__(self, other):
+        return self._val < other
+
+    def __gt__(self, other):
+        return self._val > other

--- a/onnx_chainer/variable.py
+++ b/onnx_chainer/variable.py
@@ -24,6 +24,7 @@ def _cast_shape_variable(outputs, in_args, in_kwargs):
 
 def _cast_shape_item_variable(outputs, in_args, in_kwargs):
     assert len(outputs) == 1
+    assert len(in_args) == 2  # input and item
     if isinstance(in_args[0], ShapeVariable) and len(in_args[1]) == 1:
         if isinstance(in_args[1][0], int):
             return ShapeItemVariable.create(outputs[0])

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -264,7 +264,7 @@ def test_aaa():
     from onnx_chainer.replace_func import as_funcnode
 
     import onnx_chainer.variable
-    path = gen_test_data_set(model, x, 'aaa', 10)
+    path = gen_test_data_set(model, x, 'aaa', 10, input_shape=('batch_size',)+(x.shape[1:]))
 
     x2 = np.random.rand(5, 3, 28, 28).astype(np.float32)
     path2 = gen_test_data_set(model, x2, 'aaa2', 10)

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -265,12 +265,10 @@ def test_aaa():
 
     import onnx_chainer.variable
     path = gen_test_data_set(model, x, 'aaa', 10)
-    print(path)
 
     x2 = np.random.rand(5, 3, 28, 28).astype(np.float32)
     # x2 = VVariable(x2)
     path2 = gen_test_data_set(model, x2, 'aaa2', 10)
-    print(path2)
     import os
     import shutil
     shutil.copy(os.path.join(path, 'model.onnx'), os.path.join(path2, 'model.onnx'))

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -243,3 +243,37 @@ class TestUnusedLink(ONNXModelTest):
             self.expect(model, x)
             assert len(w) == 1
             assert '/l2/W' in str(w[-1].message)
+
+
+def test_aaa():
+    model = chainer.Sequential(
+        L.Convolution2D(None, 16, 5, 1, 2),
+        F.relu,
+        L.Convolution2D(16, 8, 5, 1, 2),
+        F.relu,
+        L.Convolution2D(8, 5, 5, 1, 2),
+        F.relu,
+        L.Linear(None, 100),
+        F.relu,
+        L.Linear(100, 10)
+    )
+    x = np.random.rand(10, 3, 28, 28).astype(np.float32)
+
+    from onnx_chainer.testing.get_test_data_set import gen_test_data_set
+    from onnx_chainer.testing.test_onnxruntime import check_model_expect
+    from onnx_chainer.replace_func import as_funcnode
+
+    import onnx_chainer.variable
+    path = gen_test_data_set(model, x, 'aaa', 10)
+    print(path)
+
+    x2 = np.random.rand(5, 3, 28, 28).astype(np.float32)
+    # x2 = VVariable(x2)
+    path2 = gen_test_data_set(model, x2, 'aaa2', 10)
+    print(path2)
+    import os
+    # import shutil
+    # shutil.copy(os.path.join(path, 'model.onnx'), os.path.join(path2, 'model.onnx'))
+
+    check_model_expect(path)
+    check_model_expect(path2)

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -267,7 +267,6 @@ def test_aaa():
     path = gen_test_data_set(model, x, 'aaa', 10)
 
     x2 = np.random.rand(5, 3, 28, 28).astype(np.float32)
-    # x2 = VVariable(x2)
     path2 = gen_test_data_set(model, x2, 'aaa2', 10)
     import os
     import shutil

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -272,8 +272,8 @@ def test_aaa():
     path2 = gen_test_data_set(model, x2, 'aaa2', 10)
     print(path2)
     import os
-    # import shutil
-    # shutil.copy(os.path.join(path, 'model.onnx'), os.path.join(path2, 'model.onnx'))
+    import shutil
+    shutil.copy(os.path.join(path, 'model.onnx'), os.path.join(path2, 'model.onnx'))
 
     check_model_expect(path)
     check_model_expect(path2)


### PR DESCRIPTION
Shape size can be changed but ONNX-Chainer cannot deal with it because shape is not represented as computational graph and fixed when passed to functions, like following case:

```
batch_size = x.shape[0]
x = x.reshape((batch_size, -1))  # batch_size is set to Reshape node as number
```

To handle this, introduce `enable_shape_var` option, then `chainer.Variable.shape` returns as `chainer.Variable` and make computation graph even shape.

This logic has strong side effect and cannot pass ordinal code such as:

```
# enable_shape_var = True
shape = x.shape  # returns as chainer.Variable
y = np.empty(shape)  # error because numpy.empty cannot handle Variable type
```

So pay attention to use this option.

Not set the option:

<img width="604" alt="Screen Shot 2019-07-17 at 17 30 25" src="https://user-images.githubusercontent.com/414255/61360191-e4f1a000-a8b8-11e9-9f81-7c7c065cc92b.png">

Set the option

<img width="711" alt="Screen Shot 2019-07-17 at 17 32 33" src="https://user-images.githubusercontent.com/414255/61360211-f044cb80-a8b8-11e9-9b7d-73ed670e5318.png">


TODO:

I'll separate this PR

- [x] add reshape to deal with dynamic shape -> #194 
- [x] add shape converter -> #193 
- [ ] add `enable_shape_var` option