### PR TITLE
Support Shape operator

### DIFF
--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -23,6 +23,7 @@ from onnx_chainer.functions.array import convert_Repeat  # NOQA
 from onnx_chainer.functions.array import convert_Reshape  # NOQA
 from onnx_chainer.functions.array import convert_ResizeImages  # NOQA
 from onnx_chainer.functions.array import convert_Separate  # NOQA
+from onnx_chainer.functions.array import convert_Shape  # NOQA
 from onnx_chainer.functions.array import convert_Space2Depth  # NOQA
 from onnx_chainer.functions.array import convert_SplitAxis  # NOQA
 from onnx_chainer.functions.array import convert_Squeeze  # NOQA

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -481,3 +481,8 @@ def convert_Separate(func, opset_version, input_names, output_names, context,
         gb.op_output_named(
             'Squeeze', [node_name], [output_names[i]], axes=[func.axis])
     return gb.nodes()
+
+
+def convert_Shape(func, opset_version, input_names, output_names, context,
+                  parameters):
+    return onnx_helper.make_node('Shape', input_names, output_names),

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -30,6 +30,7 @@ _supported_function_node_set = {
     'Reshape',
     'ResizeImages',
     'Separate',
+    'Shape',
     'Space2Depth',
     'SplitAxis',
     'Squeeze',

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -344,7 +344,7 @@ class TestShape(ONNXModelTest):
 
             @as_funcnode('Shape')
             def shape(self, x):
-                # ONNX Shape operator constrains to ruturn int64 type
+                # ONNX Shape operator constrains to return int64 type
                 return np.array(x.shape)
 
             def forward(self, x):

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -331,3 +331,27 @@ class TestStack(ONNXModelTest):
                   shape in self.in_shapes]
 
         self.expect(model, xs, name=self.name)
+
+
+class TestShape(ONNXModelTest):
+
+    def test_output(self):
+        from onnx_chainer.replace_func import as_funcnode
+
+        class Model(chainer.Chain):
+            def __init__(self):
+                super().__init__()
+
+            @as_funcnode('Shape')
+            def shape(self, x):
+                # ONNX Shape operator constrains to ruturn int64 type
+                return np.array(x.shape)
+
+            def forward(self, x):
+                # use shape method instead of x.shape to connect graph.
+                return self.shape(x)
+
+        model = Model()
+        x = input_generator.increasing(3, 4, 5)
+
+        self.expect(model, (x,))


### PR DESCRIPTION
Chainer does not have shape function, but it's better to output shape operator when the graph has shape node which using `fake_as_funcnode` util.