### PR TITLE
Support dynamic reshape

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -211,9 +211,15 @@ def convert_Reshape(func, opset_version, input_names,
             shape=func.shape
         ),
     elif opset_version == 5:
-        shape_name = context.add_param(
-            np.asarray(list(func.shape), dtype=np.int64), 'shape')
-        input_names.append(shape_name)
+        if hasattr(func, 'shape'):
+            # if the function has shape parameter, means not dynamic
+            assert len(input_names) == 1
+            shape_name = context.add_param(
+                np.asarray(list(func.shape), dtype=np.int64), 'shape')
+            input_names.append(shape_name)
+        else:
+            if len(input_names) != 2:
+                raise ValueError('shape must be set as parameter or 2nd input')
 
         return onnx_helper.make_node(
             'Reshape', input_names, output_names,

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -345,7 +345,7 @@ class TestDynamicReshape(ONNXModelTest):
             @as_funcnode('Reshape')
             def dynamic_reshape(self, x, shape):
                 # shape is expected as variable type
-                return x.array.reshape(shape.array)
+                return F.reshape(x, tuple(shape.array))
 
             def forward(self, x, shape):
                 return self.dynamic_reshape(x, shape)


### PR DESCRIPTION
ONNX Reshape Op supports dynamic shape from opset 5. Chainer does not support it, but ONNX-Chainer could support when 2nd. arguments are variable.