### PR TITLE
Use Constant instead of inputs+initializer

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -46,11 +46,6 @@ def convert_parameter(parameter, context):
                 type(parameter)))
     array = chainer.cuda.to_cpu(array)
     tensor = numpy_helper.from_array(array, context.get_name(parameter))
-    # TODO(take-cheeze): Workaround until this is merged:
-    # https://github.com/onnx/onnx/pull/2085
-    if array.ndim == 1 and tensor.data_type == onnx.TensorProto.FLOAT:
-        tensor.ClearField('raw_data')
-        tensor.float_data[:] = array.tolist()
     return tensor
 
 

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -368,8 +368,7 @@ def convert_Repeat(func, opset_version, input_names, output_names, context,
         return gb.nodes()
 
     if opset_version in [9, 10]:
-        # TODO(hamaji): Check if why `add_const` does not work here.
-        scales_name = context.add_param(
+        scales_name = context.add_const(
             np.array(scales, dtype=np.float32), 'scales')
         inputs.append(scales_name)
         op = 'Upsample' if opset_version == 9 else 'Resize'

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -411,7 +411,7 @@ def convert_ResizeImages(func, opset_version, input_names, output_names,
                                      scales=scales, mode=mode),
 
     if opset_version in [9, 10]:
-        scales_name = context.add_param(
+        scales_name = context.add_const(
             np.array(scales, dtype=np.float32), 'scales')
         input_names.append(scales_name)
         op = 'Upsample' if opset_version == 9 else 'Resize'

--- a/onnx_chainer/functions/loss.py
+++ b/onnx_chainer/functions/loss.py
@@ -33,8 +33,9 @@ def convert_SoftmaxCrossEntropy(
     gb = onnx_helper.GraphBuilder()
     x, t = input_names
     y_log = gb.op('LogSoftmax', [x])
-    depth = gb.const(np.array([x_var.shape[1]], dtype=np.int32))
-    zeroone = gb.const(np.array([0, 1], dtype=x_var.dtype))
+    depth = context.add_const(np.array([x_var.shape[1]], dtype=np.int32),
+                              'depth')
+    zeroone = context.add_const(np.array([0, 1], dtype=x_var.dtype), 'zeroone')
     th = gb.op('OneHot', [t, depth, zeroone])
     s0 = gb.op('Mul', [y_log, th])
     sn = gb.op('Neg', [s0])

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -17,7 +17,7 @@ def convert_Add(func, opset_version, input_names, output_names,
 @support((1, 6, 7))
 def convert_AddConstant(func, opset_version, input_names,
                         output_names, context, parameters):
-    value_name = context.add_param(
+    value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
 
@@ -51,7 +51,7 @@ def convert_Mul(func, opset_version, input_names, output_names,
 @support((1, 6, 7))
 def convert_MulConstant(func, opset_version, input_names,
                         output_names, context, parameters):
-    value_name = context.add_param(
+    value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
 
@@ -95,7 +95,7 @@ def convert_Absolute(func, opset_version, input_names,
 @support((1, 7))
 def convert_PowVarConst(func, opset_version, input_names,
                         output_names, context, parameters):
-    value_name = context.add_param(
+    value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
 
@@ -144,7 +144,7 @@ def convert_MatMul(func, opset_version, input_names,
         func.inputs[1].shape[-2] if func.transb else func.inputs[1].shape[-1]
     )
     bias_tensor = np.zeros(bias_shape, dtype=func.inputs[0].dtype)
-    bias_name = context.add_param(bias_tensor, 'bias')
+    bias_name = context.add_const(bias_tensor, 'bias')
     input_names.append(bias_name)
 
     return onnx_helper.make_node(
@@ -248,7 +248,7 @@ def convert_LinearInterpolate(func, opset_version, input_names,
     typ = func.inputs[0].dtype if isinstance(
         func.inputs[0].dtype, np.dtype) else np.dtype(func.inputs[0].dtype)
 
-    one_name = context.add_param(np.array(1, dtype=typ), 'one')
+    one_name = context.add_const(np.array(1, dtype=typ), 'one')
 
     kwargs = {'consumed_inputs': [1, 1]} if opset_version == 1 else {}
     kwargs2 = {} if opset_version >= 7 else {'broadcast': 1}
@@ -278,6 +278,6 @@ def convert_Square(func, opset_version, input_names,
 @support((8,))
 def convert_BroadcastTo(func, opset_version, input_names,
                         output_names, context, parameters):
-    shape_name = context.add_param(np.array(func._shape), 'shape')
+    shape_name = context.add_const(np.array(func._shape), 'shape')
     input_names.append(shape_name)
     return onnx_helper.make_node('Expand', input_names, output_names),

--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -190,7 +190,7 @@ def convert_Unpooling2D(func, opset_version, input_names, output_names,
         return onnx_helper.make_node('Upsample', input_names, output_names,
                                      scales=scales),
     if opset_version in [9, 10]:
-        scales_name = context.add_param(
+        scales_name = context.add_const(
             np.array(scales, dtype=np.float32), 'scales')
         input_names.append(scales_name)
         op = 'Upsample' if opset_version == 9 else 'Resize'

--- a/onnx_chainer/graph.py
+++ b/onnx_chainer/graph.py
@@ -126,6 +126,9 @@ class Graph(object):
         onnx_helper.set_func_name(base_func_name)
         nodes = self.create_node(
             func_name, function, input_names, output_names)
+        # Insert constants before computation nodes.
+        self.graph.extend(self.context.constants)
+        self.context.constants.clear()
         self.graph.extend(nodes)
 
     def to_onnx_graph(self):

--- a/onnx_chainer/onnx_helper.py
+++ b/onnx_chainer/onnx_helper.py
@@ -94,18 +94,6 @@ class GraphBuilder(object):
         else:
             return tuple(node.output)
 
-    def const(self, array):
-        """Creates a Constant node of ONNX.
-
-        Args:
-          array (numpy.ndarray): A numpy array.
-
-        Returns:
-          A str of the name of the constant value.
-        """
-        tensor = onnx.numpy_helper.from_array(array)
-        return self.op('Constant', [], 1, value=tensor)
-
     def nodes(self, output_names=None):
         """Returns all nodes created so far.
 

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -197,11 +197,9 @@ class TestArrayOperators(ONNXModelTest):
         if hasattr(self, 'name'):
             name = self.name
         skip_ver = None
-        # TODO(hamaji): Always use 0 after fixing the exporter of `repeat`.
-        expected_num_initializers = None if self.ops == 'repeat' else 0
         self.expect(
             self.model, self.x, name=name, skip_outvalue_version=skip_ver,
-            expected_num_initializers=expected_num_initializers)
+            expected_num_initializers=0)
 
 
 class TestConcat(ONNXModelTest):

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -197,8 +197,11 @@ class TestArrayOperators(ONNXModelTest):
         if hasattr(self, 'name'):
             name = self.name
         skip_ver = None
+        # TODO(hamaji): Always use 0 after fixing the exporter of `repeat`.
+        expected_num_initializers = None if self.ops == 'repeat' else 0
         self.expect(
-            self.model, self.x, name=name, skip_outvalue_version=skip_ver)
+            self.model, self.x, name=name, skip_outvalue_version=skip_ver,
+            expected_num_initializers=expected_num_initializers)
 
 
 class TestConcat(ONNXModelTest):

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -273,7 +273,7 @@ class TestResizeImages(ONNXModelTest):
         self.check_out_values = None  # Skip output value check
 
         with warnings.catch_warnings(record=True) as w:
-            self.expect(self.model, self.x)
+            self.expect(self.model, self.x, expected_num_initializers=0)
         assert len(w) == 1
 
 

--- a/tests/functions_tests/test_maths.py
+++ b/tests/functions_tests/test_maths.py
@@ -71,7 +71,8 @@ class TestUnaryMathOperators(ONNXModelTest):
         if self.op_name == 'BroadcastTo':
             skip_opset_version.append(7)
         self.expect(self.model, self.a, name=name,
-                    skip_opset_version=skip_opset_version)
+                    skip_opset_version=skip_opset_version,
+                    expected_num_initializers=0)
 
 
 @testing.parameterize(
@@ -107,7 +108,8 @@ class TestBinaryMathOperators(ONNXModelTest):
 
     def test_output(self):
         name = self.op_name.lower()
-        self.expect(self.model, self.x, name=name)
+        self.expect(self.model, self.x, name=name,
+                    expected_num_initializers=0)
 
 
 @testing.parameterize(
@@ -140,4 +142,5 @@ class TestTernaryMathOperators(ONNXModelTest):
 
     def test_output(self):
         name = self.op_name.lower()
-        self.expect(self.model, self.x, name=name)
+        self.expect(self.model, self.x, name=name,
+                    expected_num_initializers=0)

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -40,7 +40,8 @@ class TestPoolings(ONNXModelTest):
         name = self.op_name
         if hasattr(self, 'condition'):
             name += '_' + self.condition
-        self.expect(self.model, self.x, name=name)
+        self.expect(self.model, self.x, name=name,
+                    expected_num_initializers=0)
 
 
 @testing.parameterize(

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -45,7 +45,8 @@ class ONNXModelTest(unittest.TestCase):
 
     def expect(self, model, args, name=None, skip_opset_version=None,
                skip_outvalue_version=None, with_warning=False,
-               custom_model_test_func=None, **kwargs):
+               custom_model_test_func=None, expected_num_initializers=None,
+               **kwargs):
         """Compare model output and test runtime output.
 
         Make an ONNX model from target model with args, and put output
@@ -61,6 +62,8 @@ class ONNXModelTest(unittest.TestCase):
             custom_model_test_func (func): A function to check generated
                 model. The functions is called before checking output values.
                 ONNX model is passed to arguments.
+            expected_num_initializers (int): The expected number of
+                initializers in the output ONNX model.
             **kwargs (dict): keyward arguments for ``onnx_chainer.export``.
         """
 
@@ -89,6 +92,10 @@ class ONNXModelTest(unittest.TestCase):
             with open(onnx_model_path, 'rb') as f:
                 onnx_model = onnx.load_model(f)
             check_all_connected_from_inputs(onnx_model)
+
+            if expected_num_initializers is not None:
+                actual_num_initializers = len(onnx_model.graph.initializer)
+                assert expected_num_initializers == actual_num_initializers
 
             graph_input_names = _get_graph_input_names(onnx_model)
             if kwargs.get('input_names', {}):


### PR DESCRIPTION
Fix #82 

With this PR, we will use `Constant` instead of `initializer` for non-parameter values.
