### PR TITLE
Fix test when set --value-check-runtime='skip'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,19 @@ def disable_experimental_warning():
         yield
     finally:
         chainer.disable_experimental_feature_warning = org_config
+
+
+@pytest.fixture(scope='function')
+def check_model_expect(request):
+    selected_runtime = request.config.getoption('value-check-runtime')
+    if selected_runtime == 'onnxruntime':
+        from onnx_chainer.testing.test_onnxruntime import check_model_expect  # NOQA
+        _checker = check_model_expect
+    elif selected_runtime == 'mxnet':
+        from onnx_chainer.testing.test_mxnet import check_model_expect
+        _checker = check_model_expect
+    else:
+        def empty_func(*args, **kwargs):
+            pass
+        _checker = empty_func
+    return _checker

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -29,19 +29,10 @@ class ONNXModelTest(unittest.TestCase):
         pass
 
     @pytest.fixture(autouse=True, scope='function')
-    def set_name(self, request):
+    def set_name(self, request, check_model_expect):
         cls_name = request.cls.__name__
         self.default_name = cls_name[len('Test'):].lower()
-        self.check_out_values = None
-        selected_runtime = request.config.getoption('value-check-runtime')
-        if selected_runtime == 'onnxruntime':
-            from onnx_chainer.testing.test_onnxruntime import check_model_expect  # NOQA
-            self.check_out_values = check_model_expect
-        elif selected_runtime == 'mxnet':
-            from onnx_chainer.testing.test_mxnet import check_model_expect
-            self.check_out_values = check_model_expect
-        else:
-            self.check_out_values = None
+        self.check_out_values = check_model_expect
 
     def expect(self, model, args, name=None, skip_opset_version=None,
                skip_outvalue_version=None, with_warning=False,

--- a/tests/test_external_converter.py
+++ b/tests/test_external_converter.py
@@ -9,10 +9,9 @@ import pytest
 from onnx_chainer import export_testcase
 from onnx_chainer import onnx_helper
 from onnx_chainer.testing import input_generator
-from onnx_chainer.testing.test_onnxruntime import check_model_expect
 
 
-def test_export_external_converters_overwrite(tmpdir):
+def test_export_external_converters_overwrite(tmpdir, check_model_expect):
     path = str(tmpdir)
 
     model = chainer.Sequential(chainer.functions.sigmoid)


### PR DESCRIPTION
A test case does not handle value check when set `--value-check-runtime skip` on pytest. On this PR, user can run test without installing onnxruntime

```bash
$ pytest --value-check-runtime skip
```