### PR TITLE
Show warnings rather than error when ksize/pad/stride condition is not satisfied

### DIFF
--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -15,12 +15,7 @@ def convert_AveragePooling2D(func, opset_version, input_names,
     ksize = [func.kh, func.kw]
     if func.cover_all:
         # Supports cover_all by setting extra padding
-        for p, s, k in zip(pad, stride, ksize):
-            if k <= p + s - 1:
-                warnings.warn(
-                    'onnxruntime may not be able to handle '
-                    '(ksize={} pad={} stride={}).'.format(k, p, s),
-                    UserWarning)
+        # NOTE: onnxruntime may not run when "k <= p + s - 1".
         pad.extend([p + s - 1 for p, s in zip(pad, stride)])
     else:
         pad = pad * 2
@@ -45,12 +40,7 @@ def convert_AveragePoolingND(func, opset_version, input_names,
     pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
-        for p, s, k in zip(pad, func.stride, func.ksize):
-            if k <= p + s - 1:
-                warnings.warn(
-                    'onnxruntime may not be able to handle '
-                    '(ksize={} pad={} stride={}).'.format(k, p, s),
-                    UserWarning)
+        # NOTE: onnxruntime may not run when "k <= p + s - 1".
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
     else:
         pad = pad * 2
@@ -77,12 +67,7 @@ def convert_MaxPooling2D(func, opset_version, input_names,
     ksize = [func.kh, func.kw]
     if func.cover_all:
         # Supports cover_all by setting extra padding
-        for p, s, k in zip(pad, stride, ksize):
-            if k <= p + s - 1:
-                warnings.warn(
-                    'onnxruntime may not be able to handle '
-                    '(ksize={} pad={} stride={}).'.format(k, p, s),
-                    UserWarning)
+        # NOTE: onnxruntime may not run when "k <= p + s - 1".
         pad.extend([p + s - 1 for p, s in zip(pad, stride)])
     else:
         pad = pad * 2
@@ -110,12 +95,7 @@ def convert_MaxPoolingND(func, opset_version, input_names,
     pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
-        for p, s, k in zip(pad, func.stride, func.ksize):
-            if k <= p + s - 1:
-                warnings.warn(
-                    'onnxruntime may not be able to handle '
-                    '(ksize={} pad={} stride={}).'.format(k, p, s),
-                    UserWarning)
+        # NOTE: onnxruntime may not run when "k <= p + s - 1".
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
     else:
         pad = pad * 2

--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -17,10 +17,10 @@ def convert_AveragePooling2D(func, opset_version, input_names,
         # Supports cover_all by setting extra padding
         for p, s, k in zip(pad, stride, ksize):
             if k <= p + s - 1:
-                raise RuntimeError(
-                    'Could not correctly export in the current setting'
-                    ' (ksize={} pad={} stride={}). Please set pad or stride to'
-                    'lower value.'.format(k, p, s))
+                warnings.warn(
+                    'onnxruntime may not be able to handle '
+                    '(ksize={} pad={} stride={}).'.format(k, p, s),
+                    UserWarning)
         pad.extend([p + s - 1 for p, s in zip(pad, stride)])
     else:
         pad = pad * 2
@@ -46,13 +46,11 @@ def convert_AveragePoolingND(func, opset_version, input_names,
     if func.cover_all:
         # Supports cover_all by setting extra padding
         for p, s, k in zip(pad, func.stride, func.ksize):
-            # Raise exception because a virtual pad for cover_all must be
-            # smaller than ksize in the current ONNX
             if k <= p + s - 1:
-                raise RuntimeError(
-                    'Could not correctly export in the current setting'
-                    ' (ksize={} pad={} stride={}). Please set pad or stride to'
-                    'lower value.'.format(k, p, s))
+                warnings.warn(
+                    'onnxruntime may not be able to handle '
+                    '(ksize={} pad={} stride={}).'.format(k, p, s),
+                    UserWarning)
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
     else:
         pad = pad * 2
@@ -81,10 +79,10 @@ def convert_MaxPooling2D(func, opset_version, input_names,
         # Supports cover_all by setting extra padding
         for p, s, k in zip(pad, stride, ksize):
             if k <= p + s - 1:
-                raise RuntimeError(
-                    'Could not correctly export in the current setting'
-                    ' (ksize={} pad={} stride={}). Please set pad or stride to'
-                    'lower value.'.format(k, p, s))
+                warnings.warn(
+                    'onnxruntime may not be able to handle '
+                    '(ksize={} pad={} stride={}).'.format(k, p, s),
+                    UserWarning)
         pad.extend([p + s - 1 for p, s in zip(pad, stride)])
     else:
         pad = pad * 2
@@ -113,13 +111,11 @@ def convert_MaxPoolingND(func, opset_version, input_names,
     if func.cover_all:
         # Supports cover_all by setting extra padding
         for p, s, k in zip(pad, func.stride, func.ksize):
-            # Raise exception because a virtual pad for cover_all must be
-            # smaller than ksize in the current ONNX
             if k <= p + s - 1:
-                raise RuntimeError(
-                    'Could not correctly export in the current setting'
-                    ' (ksize={} pad={} stride={}). Please set pad or stride to'
-                    'lower value.'.format(k, p, s))
+                warnings.warn(
+                    'onnxruntime may not be able to handle '
+                    '(ksize={} pad={} stride={}).'.format(k, p, s),
+                    UserWarning)
         pad.extend([p + s - 1 for p, s in zip(pad, func.stride)])
     else:
         pad = pad * 2

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -1,13 +1,8 @@
-import unittest
-
 import chainer
 import chainer.functions as F
 from chainer import testing
 import numpy as np
-import onnx
-import pytest
 
-import onnx_chainer
 from onnx_chainer.testing import input_generator
 from tests.helper import ONNXModelTest
 
@@ -43,29 +38,6 @@ class TestPoolings(ONNXModelTest):
             name += '_' + self.condition
         self.expect(self.model, self.x, name=name,
                     expected_num_initializers=0)
-
-
-@testing.parameterize(
-    {'name': 'max_pooling_2d',
-     'in_shape': (1, 3, 6, 5), 'args': [2, 2, 1], 'cover_all': True},
-    {'name': 'max_pooling_nd',
-     'in_shape': (1, 3, 6, 5, 4), 'args': [2, 2, 1], 'cover_all': True},
-)
-class TestPoolingsWithWarningSettings(unittest.TestCase):
-
-    def setUp(self):
-        ops = getattr(F, self.name)
-        self.model = Model(ops, self.args, self.cover_all)
-        self.x = input_generator.increasing(*self.in_shape)
-        self.fn = self.name + '.onnx'
-
-    def test_output(self):
-        for opset_version in range(
-                onnx_chainer.MINIMUM_OPSET_VERSION,
-                onnx.defs.onnx_opset_version() + 1):
-            with pytest.warns(UserWarning):
-                onnx_chainer.export(
-                    self.model, self.x, opset_version=opset_version)
 
 
 class Model(chainer.Chain):

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -5,6 +5,7 @@ import chainer.functions as F
 from chainer import testing
 import numpy as np
 import onnx
+import pytest
 
 import onnx_chainer
 from onnx_chainer.testing import input_generator
@@ -50,7 +51,7 @@ class TestPoolings(ONNXModelTest):
     {'name': 'max_pooling_nd',
      'in_shape': (1, 3, 6, 5, 4), 'args': [2, 2, 1], 'cover_all': True},
 )
-class TestPoolingsWithUnsupportedSettings(unittest.TestCase):
+class TestPoolingsWithWarningSettings(unittest.TestCase):
 
     def setUp(self):
         ops = getattr(F, self.name)
@@ -62,7 +63,7 @@ class TestPoolingsWithUnsupportedSettings(unittest.TestCase):
         for opset_version in range(
                 onnx_chainer.MINIMUM_OPSET_VERSION,
                 onnx.defs.onnx_opset_version() + 1):
-            with self.assertRaises(RuntimeError):
+            with pytest.warns(UserWarning):
                 onnx_chainer.export(
                     self.model, self.x, opset_version=opset_version)
 


### PR DESCRIPTION
Current converters of pooling operators don't allow ksize/pad/stride that does not satisfy some constraint.
This constraint is quite specific to the specification of ONNX-runtime, and so the export of the layer should be allowed even when the constraint is not satisfied.
I changed `raise RuntimeError` part to `warnings.warn(...)`.