### PR TITLE
Support input shapes option

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -451,8 +451,8 @@ def _export(model, args, filename, export_params, graph_name, save_text,
     check_onnx_model(model, external_converters, external_opset_imports)
 
     if input_shapes is not None:
-        for i in range(len(model.graph.output)):
-            model.graph.output[i].type.Clear()
+        for output in model.graph.output:
+            output.type.Clear()
         model = shape_inference.infer_shapes(model)
         check_onnx_model(model, external_converters, external_opset_imports)
 

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -132,14 +132,17 @@ def format_customized_shapes(args, shapes):
     else:
         assert isinstance(args, (chainer.Variable, chainer.get_array_types()))
         if isinstance(shapes, list):
-            if len(shape) != 1:
+            if len(shapes) != 1:
                 raise ValueError('Customized shape must be single')
-            return shapes
         elif not isinstance(shapes, tuple):
             raise ValueError(
                 'Type {} is not supported for single input'.format(
                     type(shapes)))
-        return [shapes]
+        else:
+            shapes = [shapes]
+        if len(args.shape) != len(shapes[0]):
+            raise ValueError('Shape length must be same as input')
+        return shapes
 
 
 def export(model, args, filename=None, export_params=True,

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -3,6 +3,7 @@ import chainer.functions as F
 import chainer.links as L
 from chainer import testing
 import numpy as np
+import pytest
 import unittest
 import warnings
 
@@ -245,18 +246,100 @@ class TestUnusedLink(ONNXModelTest):
             assert '/l2/W' in str(w[-1].message)
 
 
+@testing.parameterize(
+    {
+        'x_shape': (10, 3, 28, 28), 'shape_option': ('b', 3, 28, 28),
+    },
+    {
+        'x_shape': (10, 3, 28, 28),
+        'shape_option': [('b', 3, 28, 28)],
+        'condition': 'var_list'
+    },
+    {
+        'x_shape': [(10, 3, 28, 28), (8, 3, 28, 28)],
+        'shape_option': [('b', 3, 28, 28), ('b', 3, 28, 28)],
+        'condition': 'list_list'
+    },
+    {
+        'x_shape': {'1': (10, 3, 28, 28), '2': (8, 3, 28, 28)},
+        'shape_option': {'2': ('b', 3, 28, 28), '1': ('b', 3, 28, 28)},
+        'condition': 'dict_dict'
+    },
+    {
+        'x_shape': {'1': (10, 3, 28, 28), '2': (8, 3, 28, 28)},
+        'shape_option': [('b', 3, 28, 28), ('b', 3, 28, 28)],
+        'condition': 'dict_list'
+    },
+)
 class TestCustomizedInputShape(ONNXModelTest):
 
-    def setUp(self):
-        self.model = chainer.Sequential(
-            L.Convolution2D(None, 16, 5, 1, 2),
-            F.relu,
-            L.Convolution2D(16, 8, 5, 1, 2),
-            F.relu,
-            L.Convolution2D(8, 5, 5, 1, 2),
-            F.relu,
-        )
-        self.x = np.zeros((10, 3, 28, 28), dtype=np.float32)
-
     def test_output(self):
-        self.expect(self.model, self.x, input_shapes=('batch_size', 3, 28, 28))
+        class Model(chainer.Chain):
+            def __init__(self):
+                super().__init__()
+                with self.init_scope():
+                    self.l1 = L.Convolution2D(None, 16, 5, 1, 2)
+                    self.l2 = L.Convolution2D(16, 8, 5, 1, 2)
+
+            def forward(self, *xs, **kwxs):
+                if kwxs:
+                    h = F.vstack(list(kwxs.values()))
+                elif len(xs) > 1:
+                    h = F.vstack(xs)
+                else:
+                    h = xs[0]
+                h2 = self.l1(h)
+                h3 = F.relu(h2)
+                h4 = self.l2(h3)
+                return F.relu(h4)
+
+        def check_input_shape(onnx_model):
+            assert [v.type.tensor_type.shape.dim[0] == 'b' for
+                    v in onnx_model.graph.input]
+            assert [v.type.tensor_type.shape.dim[0] == 'b' for
+                    v in onnx_model.graph.output]
+
+        if isinstance(self.x_shape, tuple):
+            xs = np.zeros(self.x_shape, dtype=np.float32)
+        elif isinstance(self.x_shape, list):
+            xs = tuple(
+                np.zeros(shape, dtype=np.float32) for shape in self.x_shape)
+        else:
+            assert isinstance(self.x_shape, dict)
+            xs = {k: np.zeros(shape, dtype=np.float32) for
+                  k, shape in self.x_shape.items()}
+
+        name = 'customized_input_shape'
+        if hasattr(self, 'condition'):
+            name += '_{}'.format(self.condition)
+
+        self.expect(
+            Model(), xs, name=name, input_shapes=self.shape_option,
+            custom_model_test_func=check_input_shape)
+
+
+@pytest.mark.parametrize('x_shape,shape_option', [
+    ((10, 5), '?'),  # not tuple
+    ((10, 5), ('?', 5, 5)),  # shape length error
+    ((10, 5), [('?', 5), ('?', 5)]),  # not single
+    ([(10, 5), (10, 5)], [('?', 5), ('?', 5), ('?', 5)]),  # list length error
+    ([(10, 5), (10, 5)], [('?', 5), ('?', 5, 5)]),  # shape length error
+    ({'a': (10, 5), 'b': (10, 5)}, {'a': ('?', 5), 'c': ('?', 5)}),  # NOQA not key found
+    ({'a': (10, 5), 'b': (10, 5)}, [('?', 5), ('?', 5), ('?', 5)]),  # NOQA list length error
+    ({'a': (10, 5), 'b': (10, 5)}, {'a': ('?', 5), 'b': ('?', 5, 5)}),  # NOQA not key found
+])
+def test_invalid_customized_input_shape(x_shape, shape_option):
+    model = chainer.Sequential(F.relu)
+
+    if isinstance(x_shape, tuple):
+        xs = np.zeros(x_shape, dtype=np.float32)
+    elif isinstance(x_shape, list):
+        xs = tuple(
+            np.zeros(shape, dtype=np.float32) for shape in x_shape)
+    else:
+        assert isinstance(x_shape, dict)
+        xs = {k: np.zeros(shape, dtype=np.float32) for
+              k, shape in x_shape.items()}
+
+    with pytest.raises(ValueError):
+        export(model, xs, input_shapes=shape_option)

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -243,3 +243,20 @@ class TestUnusedLink(ONNXModelTest):
             self.expect(model, x)
             assert len(w) == 1
             assert '/l2/W' in str(w[-1].message)
+
+
+class TestCustomizedInputShape(ONNXModelTest):
+
+    def setUp(self):
+        self.model = chainer.Sequential(
+            L.Convolution2D(None, 16, 5, 1, 2),
+            F.relu,
+            L.Convolution2D(16, 8, 5, 1, 2),
+            F.relu,
+            L.Convolution2D(8, 5, 5, 1, 2),
+            F.relu,
+        )
+        self.x = np.zeros((10, 3, 28, 28), dtype=np.float32)
+
+    def test_output(self):
+        self.expect(self.model, self.x, input_shapes=('batch_size', 3, 28, 28))


### PR DESCRIPTION
fixes #187 

Example graph when set `input_shapes=('b',)+x.shape[1:]`

<img width="178" alt="image" src="https://user-images.githubusercontent.com/414255/62197848-8dc0f480-b3bb-11e9-8c28-df333052fce1.png">

[NOTE1]

Updated shape information in `value_info` are set by `onnx.shape_inference` module. There are some unsupported node by the module, like Concat. then set empty (Netron show `0` when shape is empty)

<img width="207" alt="image" src="https://user-images.githubusercontent.com/414255/62198060-e98b7d80-b3bb-11e9-90e5-e6028e11d729.png">

Some runtime (ONNXRuntime, MXNet) could run correctly even if set `0`

[NOTE2]

Currently the below code is not supported, shape value of reshaped is fixed and not set as dynamic parameter.

```
s = x.shape[0]
y = x.reshape(s, -1)
```