### PR TITLE
Drop parameters argument from converters

### DIFF
--- a/onnx_chainer/functions/activation.py
+++ b/onnx_chainer/functions/activation.py
@@ -26,8 +26,8 @@ def _convert_softmax_impl(op_type, func, input_names, output_names):
 
 
 @support((1, 6))
-def convert_ClippedReLU(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_ClippedReLU(
+        func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Clip', input_names, output_names,
@@ -42,8 +42,7 @@ def convert_ClippedReLU(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_ELU(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_ELU(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Elu', input_names, output_names,
@@ -57,8 +56,8 @@ def convert_ELU(func, opset_version, input_names, output_names,
 
 
 @support((1, 6))
-def convert_HardSigmoid(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_HardSigmoid(
+        func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'HardSigmoid', input_names, output_names,
@@ -75,8 +74,7 @@ def convert_HardSigmoid(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_LeakyReLU(func, opset_version, input_names,
-                      output_names, context, parameters):
+def convert_LeakyReLU(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'LeakyRelu', input_names, output_names,
@@ -90,14 +88,14 @@ def convert_LeakyReLU(func, opset_version, input_names,
         ),
 
 
-def convert_LogSoftmax(func, opset_version, input_names,
-                       output_names, context, parameters):
+def convert_LogSoftmax(
+        func, opset_version, input_names, output_names, context):
     return _convert_softmax_impl('LogSoftmax', func, input_names, output_names)
 
 
 @support((1, 6, 7))
-def convert_PReLUFunction(func, opset_version, input_names,
-                          output_names, context, parameters):
+def convert_PReLUFunction(
+        func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'PRelu', input_names, output_names, consumed_inputs=[1]),
@@ -108,8 +106,7 @@ def convert_PReLUFunction(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_ReLU(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_ReLU(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Relu', input_names, output_names,
@@ -119,8 +116,7 @@ def convert_ReLU(func, opset_version, input_names, output_names,
 
 
 @support((1, 6))
-def convert_Sigmoid(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Sigmoid(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Sigmoid', input_names, output_names,
@@ -129,19 +125,16 @@ def convert_Sigmoid(func, opset_version, input_names,
         return onnx_helper.make_node('Sigmoid', input_names, output_names),
 
 
-def convert_Softmax(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Softmax(func, opset_version, input_names, output_names, context):
     return _convert_softmax_impl('Softmax', func, input_names, output_names)
 
 
-def convert_Softplus(func, opset_version, input_names,
-                     output_names, context, parameters):
+def convert_Softplus(func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node('Softplus', input_names, output_names),
 
 
 @support((1, 6))
-def convert_Tanh(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Tanh(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Tanh', input_names, output_names,

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -28,8 +28,7 @@ TENSOR_TYPE_TO_NAME = {
 
 
 @support((1, 6))
-def convert_Cast(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Cast(func, opset_version, input_names, output_names, context):
     typ = func.type if isinstance(func.type, np.dtype) else np.dtype(func.type)
     if opset_version == 1:
         return onnx_helper.make_node(
@@ -44,8 +43,7 @@ def convert_Cast(func, opset_version, input_names, output_names,
 
 
 @support((1, 4))
-def convert_Concat(func, opset_version, input_names,
-                   output_names, context, parameters):
+def convert_Concat(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Concat', input_names, output_names,
@@ -58,15 +56,14 @@ def convert_Concat(func, opset_version, input_names,
         ),
 
 
-def convert_Copy(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Copy(func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node(
         'Identity', input_names, output_names
     ),
 
 
-def convert_Depth2Space(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_Depth2Space(
+        func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node(
         'DepthToSpace', input_names, output_names,
         blocksize=func.r
@@ -74,8 +71,7 @@ def convert_Depth2Space(func, opset_version, input_names,
 
 
 @support((1, 10))
-def convert_GetItem(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_GetItem(func, opset_version, input_names, output_names, context):
     x = func.inputs[0]
     axes, starts, ends = [], [], []
     squeeze_idxs, unsqueeze_idxs = [], []
@@ -141,8 +137,7 @@ def convert_GetItem(func, opset_version, input_names,
 
 
 @support((1, 2))
-def convert_Pad(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Pad(func, opset_version, input_names, output_names, context):
     if func.mode not in ['constant', 'reflect', 'edge']:
         raise ValueError(
             '{} mode is not supported in ONNX\'s Pad operation'.format(
@@ -203,8 +198,7 @@ def convert_Pad(func, opset_version, input_names, output_names,
 
 
 @support((1, 5))
-def convert_Reshape(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Reshape(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Reshape', input_names, output_names,
@@ -226,8 +220,8 @@ def convert_Reshape(func, opset_version, input_names,
         ),
 
 
-def convert_Space2Depth(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_Space2Depth(
+        func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node(
         'SpaceToDepth', input_names, output_names,
         blocksize=func.r
@@ -235,8 +229,7 @@ def convert_Space2Depth(func, opset_version, input_names,
 
 
 @support((1, 2))
-def convert_SplitAxis(func, opset_version, input_names,
-                      output_names, context, parameters):
+def convert_SplitAxis(func, opset_version, input_names, output_names, context):
     if func.indices is not None:
         indices_or_sections = func.indices
     else:
@@ -266,8 +259,7 @@ def convert_SplitAxis(func, opset_version, input_names,
         ),
 
 
-def convert_Squeeze(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Squeeze(func, opset_version, input_names, output_names, context):
     if func.axis is None:
         axis = []
         for i, s in enumerate(func.inputs[0].shape):
@@ -282,8 +274,7 @@ def convert_Squeeze(func, opset_version, input_names,
     ),
 
 
-def convert_Swapaxes(func, opset_version, input_names,
-                     output_names, context, parameters):
+def convert_Swapaxes(func, opset_version, input_names, output_names, context):
     perm = list(range(len(func.inputs[0].shape)))
     perm[func.axis1], perm[func.axis2] = perm[func.axis2], perm[func.axis1]
 
@@ -293,8 +284,7 @@ def convert_Swapaxes(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_Tile(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Tile(func, opset_version, input_names, output_names, context):
     # Add tiles and axis to graph
     if isinstance(func.reps, int):
         func.reps = [func.reps]
@@ -312,8 +302,7 @@ def convert_Tile(func, opset_version, input_names, output_names,
     return onnx_helper.make_node('Tile', input_names, output_names),
 
 
-def convert_Transpose(func, opset_version, input_names,
-                      output_names, context, parameters):
+def convert_Transpose(func, opset_version, input_names, output_names, context):
 
     if func.axes is None:
         node = onnx_helper.make_node('Transpose', input_names, output_names)
@@ -326,8 +315,8 @@ def convert_Transpose(func, opset_version, input_names,
     return node,
 
 
-def convert_ExpandDims(func, opset_version, input_names,
-                       output_names, context, parameters):
+def convert_ExpandDims(
+        func, opset_version, input_names, output_names, context):
     axis = func.axis
     if axis < 0:
         axis = len(func.inputs[0].shape) + 1 + axis
@@ -337,15 +326,13 @@ def convert_ExpandDims(func, opset_version, input_names,
 
 
 @support((9,))
-def convert_Where(func, opset_version, input_names, output_names, context,
-                  parameters):
+def convert_Where(func, opset_version, input_names, output_names, context):
     input_names.insert(0, context.get_name(func.condition))
     return onnx_helper.make_node('Where', input_names, output_names),
 
 
 @support((7, 9, 10))
-def convert_Repeat(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_Repeat(func, opset_version, input_names, output_names, context):
     repeats = func.repeats
     if len(repeats) > 1:
         raise NotImplementedError(
@@ -377,8 +364,8 @@ def convert_Repeat(func, opset_version, input_names, output_names, context,
 
 
 @support((7, 9, 10))
-def convert_ResizeImages(func, opset_version, input_names, output_names,
-                         context, parameters):
+def convert_ResizeImages(
+        func, opset_version, input_names, output_names, context):
 
     warnings.warn(
         '`resize_images` is mapped to `Upsampling` ONNX op with bilinear '
@@ -419,8 +406,7 @@ def convert_ResizeImages(func, opset_version, input_names, output_names,
                                      mode=mode),
 
 
-def convert_Stack(func, opset_version, input_names, output_names, context,
-                  parameters):
+def convert_Stack(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     axis = func.axis
     if axis < 0:
@@ -432,8 +418,7 @@ def convert_Stack(func, opset_version, input_names, output_names, context,
     return gb.nodes()
 
 
-def convert_Hstack(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_Hstack(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
     inputs = input_names
@@ -447,8 +432,7 @@ def convert_Hstack(func, opset_version, input_names, output_names, context,
     return gb.nodes()
 
 
-def convert_Vstack(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_Vstack(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
     inputs = input_names
@@ -461,8 +445,7 @@ def convert_Vstack(func, opset_version, input_names, output_names, context,
     return gb.nodes()
 
 
-def convert_Dstack(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_Dstack(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     input0_ndim = len(func.inputs[0].shape)
     inputs = input_names
@@ -478,8 +461,7 @@ def convert_Dstack(func, opset_version, input_names, output_names, context,
     return gb.nodes()
 
 
-def convert_Separate(func, opset_version, input_names, output_names, context,
-                     parameters):
+def convert_Separate(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     split_outs = gb.op(
         'Split', input_names, num_outputs=len(output_names), axis=func.axis)
@@ -489,6 +471,5 @@ def convert_Separate(func, opset_version, input_names, output_names, context,
     return gb.nodes()
 
 
-def convert_Shape(func, opset_version, input_names, output_names, context,
-                  parameters):
+def convert_Shape(func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node('Shape', input_names, output_names),

--- a/onnx_chainer/functions/connection.py
+++ b/onnx_chainer/functions/connection.py
@@ -4,9 +4,8 @@ from onnx_chainer.functions.opset_version import support
 from onnx_chainer import onnx_helper
 
 
-def convert_Convolution2DFunction(func, opset_version,
-                                  input_names, output_names, context,
-                                  parameters):
+def convert_Convolution2DFunction(
+        func, opset_version, input_names, output_names, context):
     if hasattr(func, 'dy') and hasattr(func, 'dx'):
         node = onnx_helper.make_node(
             'Conv', input_names, output_names,
@@ -29,9 +28,8 @@ def convert_Convolution2DFunction(func, opset_version,
     return node,
 
 
-def convert_ConvolutionND(func, opset_version, input_names,
-                          output_names, context,
-                          parameters):
+def convert_ConvolutionND(
+        func, opset_version, input_names, output_names, context):
     pad = []
     x_ndim = len(func.inputs[0].shape)
     w_ndim = len(func.inputs[1].shape)
@@ -50,9 +48,8 @@ def convert_ConvolutionND(func, opset_version, input_names,
     ),
 
 
-def convert_Deconvolution2DFunction(func, opset_version,
-                                    input_names, output_names, context,
-                                    parameters):
+def convert_Deconvolution2DFunction(
+        func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node(
         'ConvTranspose', input_names, output_names,
         kernel_shape=func.inputs[1].shape[2:],
@@ -64,8 +61,8 @@ def convert_Deconvolution2DFunction(func, opset_version,
     ),
 
 
-def convert_DeconvolutionND(func, opset_version, input_names,
-                            output_names, context, parameters):
+def convert_DeconvolutionND(
+        func, opset_version, input_names, output_names, context):
     pad = []
     x_ndim = len(func.inputs[0].shape)
     w_ndim = len(func.inputs[1].shape)
@@ -85,8 +82,8 @@ def convert_DeconvolutionND(func, opset_version, input_names,
     ),
 
 
-def convert_EmbedIDFunction(func, opset_version, input_names,
-                            output_names, context, parameters):
+def convert_EmbedIDFunction(
+        func, opset_version, input_names, output_names, context):
     x_index_name, W_name = input_names
     input_names = [W_name, x_index_name]
 
@@ -99,8 +96,8 @@ def convert_EmbedIDFunction(func, opset_version, input_names,
 
 
 @support((1, 6, 7))
-def convert_LinearFunction(func, opset_version, input_names,
-                           output_names, context, parameters):
+def convert_LinearFunction(
+        func, opset_version, input_names, output_names, context):
     # When the func has bias
     if len(func.inputs) == 2:
         bias_dim = func.inputs[1].shape[0]

--- a/onnx_chainer/functions/converter.py
+++ b/onnx_chainer/functions/converter.py
@@ -2,7 +2,7 @@ class FunctionConverterParams(object):
 
     def __init__(
             self, func=None, opset_version=None, input_names=None,
-            output_names=None, context=None, parameters=None):
+            output_names=None, context=None):
         """Wrapper of converter parameters
 
         Exporter set this parameters to the target converter's argument.
@@ -18,7 +18,6 @@ class FunctionConverterParams(object):
             input_names (list): List of input names.
             output_names (list): List of ouptut names.
             context (~onnx_chainer.context.Context): Context for Exporting
-            parameters (list): List of ~chainer.Parameter
         """
 
         self.func = func
@@ -26,7 +25,6 @@ class FunctionConverterParams(object):
         self.input_names = input_names
         self.output_names = output_names
         self.context = context
-        self.parameters = parameters
 
 
 class FunctionConverter(object):
@@ -49,7 +47,5 @@ class FunctionConverter(object):
         input_names = params.input_names
         output_names = params.output_names
         context = params.context
-        parameters = params.parameters
         return self.converter(
-            func, opset_version, input_names, output_names, context,
-            parameters)
+            func, opset_version, input_names, output_names, context)

--- a/onnx_chainer/functions/loss.py
+++ b/onnx_chainer/functions/loss.py
@@ -7,8 +7,7 @@ from onnx_chainer import onnx_helper
 
 @support((9,))
 def convert_SoftmaxCrossEntropy(
-        func, opset_version, input_names,
-        output_names, context, parameters):
+        func, opset_version, input_names, output_names, context):
     # obtain input variable
     if not isinstance(func, chainer.FunctionNode):
         raise NotImplementedError(

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -6,8 +6,7 @@ from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
-def convert_Add(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Add(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Add', input_names, output_names, consumed_inputs=[1, 1]),
@@ -16,8 +15,8 @@ def convert_Add(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_AddConstant(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_AddConstant(
+        func, opset_version, input_names, output_names, context):
     value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
@@ -30,8 +29,7 @@ def convert_AddConstant(func, opset_version, input_names,
 
 
 @support((1, 6, 7))
-def convert_Sub(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Sub(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Sub', input_names, output_names, consumed_inputs=[1, 1]),
@@ -40,8 +38,8 @@ def convert_Sub(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_SubFromConstant(func, opset_version, input_names, output_names,
-                            context, parameters):
+def convert_SubFromConstant(
+        func, opset_version, input_names, output_names, context):
     value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names[:0] = [value_name]
@@ -54,8 +52,7 @@ def convert_SubFromConstant(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_Mul(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Mul(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Mul', input_names, output_names, consumed_inputs=[1, 1]),
@@ -64,8 +61,8 @@ def convert_Mul(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_MulConstant(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_MulConstant(
+        func, opset_version, input_names, output_names, context):
     value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
@@ -78,8 +75,7 @@ def convert_MulConstant(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_Neg(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Neg(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Neg', input_names, output_names, consumed_inputs=[1, 1]),
@@ -88,8 +84,7 @@ def convert_Neg(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_Div(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Div(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Div', input_names, output_names, consumed_inputs=[1, 1]),
@@ -98,8 +93,8 @@ def convert_Div(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_DivFromConstant(func, opset_version, input_names, output_names,
-                            context, parameters):
+def convert_DivFromConstant(
+        func, opset_version, input_names, output_names, context):
     value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names[:0] = [value_name]
@@ -112,8 +107,7 @@ def convert_DivFromConstant(func, opset_version, input_names, output_names,
 
 
 @support((1, 6))
-def convert_Absolute(func, opset_version, input_names,
-                     output_names, context, parameters):
+def convert_Absolute(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Abs', input_names, output_names, consumed_inputs=[1]),
@@ -122,8 +116,8 @@ def convert_Absolute(func, opset_version, input_names,
 
 
 @support((1, 7))
-def convert_PowVarConst(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_PowVarConst(
+        func, opset_version, input_names, output_names, context):
     value_name = context.add_const(
         np.array(func.value, dtype=func.inputs[0].dtype), 'value')
     input_names.append(value_name)
@@ -133,8 +127,7 @@ def convert_PowVarConst(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_Clip(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Clip(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Clip', input_names, output_names,
@@ -151,8 +144,7 @@ def convert_Clip(func, opset_version, input_names, output_names,
 
 
 @support((1, 6))
-def convert_Exp(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Exp(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Exp', input_names, output_names, consumed_inputs=[1, 1]),
@@ -160,13 +152,11 @@ def convert_Exp(func, opset_version, input_names, output_names,
         return onnx_helper.make_node('Exp', input_names, output_names),
 
 
-def convert_Identity(func, opset_version, input_names,
-                     output_names, context, parameters):
+def convert_Identity(func, opset_version, input_names, output_names, context):
     return onnx_helper.make_node('Identity', input_names, output_names),
 
 
-def convert_MatMul(func, opset_version, input_names,
-                   output_names, context, parameters):
+def convert_MatMul(func, opset_version, input_names, output_names, context):
     ndim_a = len(func.inputs[0].shape)
     ndim_b = len(func.inputs[1].shape)
 
@@ -184,8 +174,7 @@ def convert_MatMul(func, opset_version, input_names,
 
 
 @support((1, 6, 8))
-def convert_Maximum(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Maximum(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Max', input_names, output_names, consumed_inputs=[1, 1]),
@@ -194,8 +183,7 @@ def convert_Maximum(func, opset_version, input_names,
 
 
 @support((1, 6, 8))
-def convert_Minimum(func, opset_version, input_names,
-                    output_names, context, parameters):
+def convert_Minimum(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Min', input_names, output_names, consumed_inputs=[1, 1]),
@@ -204,8 +192,7 @@ def convert_Minimum(func, opset_version, input_names,
 
 
 @support((1, 6))
-def convert_Sqrt(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Sqrt(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Sqrt', input_names, output_names, consumed_inputs=[1, 1]),
@@ -213,16 +200,14 @@ def convert_Sqrt(func, opset_version, input_names, output_names,
         return onnx_helper.make_node('Sqrt', input_names, output_names),
 
 
-def convert_RsqrtGPU(func, opset_version, input_names, output_names,
-                     context, parameters):
+def convert_RsqrtGPU(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     sqrt_out = gb.op('Sqrt', input_names)
     gb.op('Reciprocal', [sqrt_out])
     return gb.nodes(output_names)
 
 
-def convert_LogSumExp(func, opset_version, input_names,
-                      output_names, context, parameters):
+def convert_LogSumExp(func, opset_version, input_names, output_names, context):
     # Use keepdims=False by default
     # since the chainer does not support keepdims option
     kwargs = {'keepdims': False}
@@ -234,8 +219,7 @@ def convert_LogSumExp(func, opset_version, input_names,
         'ReduceLogSumExp', input_names, output_names, **kwargs),
 
 
-def convert_Max(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Max(func, opset_version, input_names, output_names, context):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
@@ -243,8 +227,7 @@ def convert_Max(func, opset_version, input_names, output_names,
         'ReduceMax', input_names, output_names, **kwargs),
 
 
-def convert_Mean(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Mean(func, opset_version, input_names, output_names, context):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
@@ -252,8 +235,7 @@ def convert_Mean(func, opset_version, input_names, output_names,
         'ReduceMean', input_names, output_names, **kwargs),
 
 
-def convert_Min(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Min(func, opset_version, input_names, output_names, context):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
@@ -261,8 +243,7 @@ def convert_Min(func, opset_version, input_names, output_names,
         'ReduceMin', input_names, output_names, **kwargs),
 
 
-def convert_Prod(func, opset_version, input_names, output_names,
-                 context, parameters):
+def convert_Prod(func, opset_version, input_names, output_names, context):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
@@ -270,8 +251,7 @@ def convert_Prod(func, opset_version, input_names, output_names,
         'ReduceProd', input_names, output_names, **kwargs),
 
 
-def convert_Sum(func, opset_version, input_names, output_names,
-                context, parameters):
+def convert_Sum(func, opset_version, input_names, output_names, context):
     kwargs = {'keepdims': func.keepdims}
     if func.axis is not None:
         kwargs['axes'] = func.axis
@@ -280,8 +260,8 @@ def convert_Sum(func, opset_version, input_names, output_names,
 
 
 @support((1, 6, 7))
-def convert_LinearInterpolate(func, opset_version, input_names,
-                              output_names, context, parameters):
+def convert_LinearInterpolate(
+        func, opset_version, input_names, output_names, context):
     typ = func.inputs[0].dtype if isinstance(
         func.inputs[0].dtype, np.dtype) else np.dtype(func.inputs[0].dtype)
 
@@ -301,8 +281,7 @@ def convert_LinearInterpolate(func, opset_version, input_names,
 
 
 @support((1, 6, 7))
-def convert_Square(func, opset_version, input_names,
-                   output_names, context, parameters):
+def convert_Square(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Mul', [input_names[0], input_names[0]], output_names,
@@ -313,8 +292,8 @@ def convert_Square(func, opset_version, input_names,
 
 
 @support((8,))
-def convert_BroadcastTo(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_BroadcastTo(
+        func, opset_version, input_names, output_names, context):
     shape_name = context.add_const(np.array(func._shape), 'shape')
     input_names.append(shape_name)
     return onnx_helper.make_node('Expand', input_names, output_names),
@@ -337,12 +316,10 @@ def _argminmax_nodes(op_name, func, input_names, output_names, context):
 
 
 @support((6,))
-def convert_ArgMax(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_ArgMax(func, opset_version, input_names, output_names, context):
     return _argminmax_nodes('ArgMax', func, input_names, output_names, context)
 
 
 @support((6,))
-def convert_ArgMin(func, opset_version, input_names, output_names, context,
-                   parameters):
+def convert_ArgMin(func, opset_version, input_names, output_names, context):
     return _argminmax_nodes('ArgMin', func, input_names, output_names, context)

--- a/onnx_chainer/functions/noise.py
+++ b/onnx_chainer/functions/noise.py
@@ -5,9 +5,7 @@ from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
-def convert_Dropout(
-        func, opset_version, input_names,
-        output_names, context, parameters):
+def convert_Dropout(func, opset_version, input_names, output_names, context):
     if opset_version == 1:
         return onnx_helper.make_node(
             'Dropout', input_names, output_names,

--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -8,8 +8,8 @@ from onnx_chainer import onnx_helper
 
 
 @support((1, 6, 7))
-def convert_BatchNormalization(func, opset_version, input_names,
-                               output_names, context, parameters):
+def convert_BatchNormalization(
+        func, opset_version, input_names, output_names, context):
     is_fixed_bn = len(func.inputs) > 3
 
     # NOTE(disktnk):
@@ -90,16 +90,14 @@ def convert_BatchNormalization(func, opset_version, input_names,
 
 
 @support((1, 6, 7))
-def convert_FixedBatchNormalization(func, opset_version,
-                                    input_names, output_names, context,
-                                    parameters):
+def convert_FixedBatchNormalization(
+        func, opset_version, input_names, output_names, context):
     return convert_BatchNormalization(
-        func, opset_version, input_names, output_names, context, parameters)
+        func, opset_version, input_names, output_names, context)
 
 
-def convert_LocalResponseNormalization(func, opset_version,
-                                       input_names, output_names, context,
-                                       parameters):
+def convert_LocalResponseNormalization(
+        func, opset_version, input_names, output_names, context):
     size = int(func.n)
     return onnx_helper.make_node(
         'LRN', input_names, output_names,
@@ -110,8 +108,8 @@ def convert_LocalResponseNormalization(func, opset_version,
     ),
 
 
-def convert_NormalizeL2(func, opset_version, input_names,
-                        output_names, context, parameters):
+def convert_NormalizeL2(
+        func, opset_version, input_names, output_names, context):
     if isinstance(func.axis, tuple) and len(func.axis) != 1:
         raise ValueError(
             'Normalization along with multiple axes ({}) are not supported in '

--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -8,8 +8,8 @@ from onnx_chainer import onnx_helper
 
 
 @support((1, 7))
-def convert_AveragePooling2D(func, opset_version, input_names,
-                             output_names, context, parameters):
+def convert_AveragePooling2D(
+        func, opset_version, input_names, output_names, context):
     pad = [func.ph, func.pw]
     stride = [func.sy, func.sx]
     ksize = [func.kh, func.kw]
@@ -35,8 +35,8 @@ def convert_AveragePooling2D(func, opset_version, input_names,
 
 
 @support((1, 7))
-def convert_AveragePoolingND(func, opset_version, input_names,
-                             output_names, context, parameters):
+def convert_AveragePoolingND(
+        func, opset_version, input_names, output_names, context):
     pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
@@ -60,8 +60,8 @@ def convert_AveragePoolingND(func, opset_version, input_names,
 
 
 @support((1, 8))
-def convert_MaxPooling2D(func, opset_version, input_names,
-                         output_names, context, parameters):
+def convert_MaxPooling2D(
+        func, opset_version, input_names, output_names, context):
     pad = [func.ph, func.pw]
     stride = [func.sy, func.sx]
     ksize = [func.kh, func.kw]
@@ -90,8 +90,8 @@ def convert_MaxPooling2D(func, opset_version, input_names,
 
 
 @support((1, 8))
-def convert_MaxPoolingND(func, opset_version, input_names,
-                         output_names, context, parameters):
+def convert_MaxPoolingND(
+        func, opset_version, input_names, output_names, context):
     pad = list(func.pad[:])
     if func.cover_all:
         # Supports cover_all by setting extra padding
@@ -117,8 +117,8 @@ def convert_MaxPoolingND(func, opset_version, input_names,
         ),
 
 
-def convert_ROIPooling2D(func, opset_version, input_names,
-                         output_names, context, parameters):
+def convert_ROIPooling2D(
+        func, opset_version, input_names, output_names, context):
     warnings.warn(
         'It\'s possible that output does not match with Chainer, please check '
         'each runtime\'s implementation. For example, when input x has '
@@ -132,8 +132,8 @@ def convert_ROIPooling2D(func, opset_version, input_names,
 
 
 @support((7, 9, 10))
-def convert_Unpooling2D(func, opset_version, input_names, output_names,
-                        context, parameters):
+def convert_Unpooling2D(
+        func, opset_version, input_names, output_names, context):
     pad = [func.ph, func.pw]
     stride = [func.sy, func.sx]
     ksize = [func.kh, func.kw]

--- a/onnx_chainer/graph.py
+++ b/onnx_chainer/graph.py
@@ -66,7 +66,7 @@ class Graph(object):
             raise ValueError('{} is not supported'.format(func_name))
         params = FunctionConverterParams(
             func, self.specified_opset_version, input_names, output_names,
-            self.context, self.context.parameters)
+            self.context)
         nodes = converter(params)
         return list(nodes)
 


### PR DESCRIPTION
`parameters` is included in context.

before

```
def convert_func(..., context, parameters):
    parameters.append(p)
```

after

```
def convert_fun(..., context):
    context.parameters.append(p)
```