### PR TITLE
Add opset option on pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--opset-versions', dest='opset-versions', default=None,
         help='select opset versions, select from "min", "latest", '
-             'or set list of number like "9,10"')
+             'or a list of numbers like "9,10"')
 
 
 @pytest.fixture(scope='function')
@@ -55,7 +55,7 @@ def target_opsets(request):
         return [max_version]
     else:
         try:
-            versions = [int(i) for i in opsets.split(',') if not i == '']
+            versions = [int(i) for i in opsets.split(',')]
         except ValueError as e:
             raise ValueError('cannot convert {} to versions list'.format(
                 opsets))

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -25,8 +25,8 @@ def load_input_data(data_dir):
 class ONNXModelTest(unittest.TestCase):
 
     @pytest.fixture(autouse=True)
-    def set_config(self, disable_experimental_warning):
-        pass
+    def set_config(self, disable_experimental_warning, target_opsets):
+        self.target_opsets = target_opsets
 
     @pytest.fixture(autouse=True, scope='function')
     def set_name(self, request, check_model_expect):
@@ -62,8 +62,7 @@ class ONNXModelTest(unittest.TestCase):
         if test_name is None:
             test_name = self.default_name
 
-        for opset_version in range(onnx_chainer.MINIMUM_OPSET_VERSION,
-                                   onnx.defs.onnx_opset_version() + 1):
+        for opset_version in self.target_opsets:
             if skip_opset_version is not None and\
                     opset_version in skip_opset_version:
                 continue


### PR DESCRIPTION
support "opset-versions" option

```
$pytest --opset-versions=latest tests/functions_tests/test_activations.py
```

- `"latest"`: test only latest version of onnx (not onnx-chainer) library, if use onnx==1.5, use 10
- `"min"`: test only minimum version supported by onnx-chainer, currently 7
- list phrase: test on specialized versions, for example, set `"7,10"` use upset version 7 and 10