### PR TITLE
Do not emit redundant axes for slice with `:`

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -98,6 +98,8 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
                 raise ValueError(
                     'GetItem with {}step slicing is not supported in ONNX '
                     'Slice operator'.format(idx.step))
+            if idx.start is None and idx.stop is None:
+                continue
             axes.append(axis)
             starts.append(0 if idx.start is None else idx.start)
             ends.append(x.shape[axis] if idx.stop is None else idx.stop)

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -144,6 +144,10 @@ from tests.helper import ONNXModelTest
      'input_argname': 'x',
      'args': {'slices': (0, None, Ellipsis, 0, None, slice(0, 2), None, 0)},
      'name': 'get_item_complicated'},
+    {'ops': 'get_item', 'input_shape': (2, 2, 3),
+     'input_argname': 'x',
+     'args': {'slices': (slice(None), slice(0, 1), slice(None, 2))},
+     'name': 'get_item_start_from_none'},
 
     # expand_dims
     {'ops': 'expand_dims', 'input_shape': (3,),


### PR DESCRIPTION
The added test was not failing even with this change, but I'm not sure how we should test this.