### PR TITLE
Follow UserWarning handling on testing

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -500,10 +500,10 @@ def check_onnx_model(onnx_model, external_converters, external_opset_imports):
                         '`external_opset_imports` when using '
                         '`external_converters` on exporting. Please take care '
                         'about ONNX format check is insufficient. Error '
-                        'message:\n{}'.format(str(e)))
+                        'message:\n{}'.format(str(e)), UserWarning)
             else:
                 warnings.warn(
                     'ValidationError is occurred but ignored because '
                     'exporting with `external_converters`. Please take care '
                     'about ONNX format check is insufficient. Error '
-                    'message:\n{}'.format(str(e)))
+                    'message:\n{}'.format(str(e)), UserWarning)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ exclude = .eggs,*.egg,build,docs,.git,venv
 
 [tool:pytest]
 filterwarnings =
+    error
+    ignore::FutureWarning:chainer\.utils\.experimental
     # ``collections.MutableSequence`` in protobuf is warned by
     # Python 3.7.
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning:google\.protobuf

--- a/tests/functions_tests/test_arrays.py
+++ b/tests/functions_tests/test_arrays.py
@@ -1,5 +1,3 @@
-import warnings
-
 import chainer
 import chainer.functions as F
 from chainer import testing
@@ -316,9 +314,8 @@ class TestResizeImages(ONNXModelTest):
 
         self.check_out_values = None  # Skip output value check
 
-        with warnings.catch_warnings(record=True) as w:
+        with testing.assert_warns(UserWarning):
             self.expect(self.model, self.x, expected_num_initializers=0)
-        assert len(w) == 1
 
 
 @testing.parameterize(

--- a/tests/functions_tests/test_poolings.py
+++ b/tests/functions_tests/test_poolings.py
@@ -88,4 +88,5 @@ class TestROIPooling2D(ONNXModelTest):
         self.model = Model(kwargs)
 
     def test_output(self):
-        self.expect(self.model, [self.x, self.rois], with_warning=True)
+        with testing.assert_warns(UserWarning):
+            self.expect(self.model, [self.x, self.rois])

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -60,9 +60,8 @@ class ONNXModelChecker(object):
         self.check_out_values = check_model_expect
 
     def expect(self, model, args, name=None, skip_opset_version=None,
-               skip_outvalue_version=None, with_warning=False,
-               custom_model_test_func=None, expected_num_initializers=None,
-               **kwargs):
+               skip_outvalue_version=None, custom_model_test_func=None,
+               expected_num_initializers=None, **kwargs):
         """Compare model output and test runtime output.
 
         Make an ONNX model from target model with args, and put output
@@ -74,7 +73,6 @@ class ONNXModelChecker(object):
             name (str): name of test. Set class name on default.
             skip_opset_version (list): Versions to skip test.
             skip_outvalue_version (list): Versions to skip output value check.
-            with_warning (bool): If True, check warnings.
             custom_model_test_func (func): A function to check generated
                 model. The functions is called before checking output values.
                 ONNX model is passed to arguments.
@@ -93,14 +91,8 @@ class ONNXModelChecker(object):
                 continue
 
             dir_name = 'test_' + test_name
-            if with_warning:
-                with warnings.catch_warnings(record=True) as w:
-                    test_path = gen_test_data_set(
-                        model, args, dir_name, opset_version, **kwargs)
-                assert len(w) == 1
-            else:
-                test_path = gen_test_data_set(
-                    model, args, dir_name, opset_version, **kwargs)
+            test_path = gen_test_data_set(
+                model, args, dir_name, opset_version, **kwargs)
 
             onnx_model_path = os.path.join(test_path, 'model.onnx')
             assert os.path.isfile(onnx_model_path)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import unittest
-import warnings
 
 import chainer
 import numpy as np

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import chainer
 import chainer.functions as F
@@ -338,10 +337,8 @@ class TestUnusedLink(ONNXModelTest):
         model = MLP(100, 10)
         x = np.random.rand(1, 768).astype(np.float32)
 
-        with warnings.catch_warnings(record=True) as w:
+        with testing.assert_warns(UserWarning):
             self.expect(model, x)
-            assert len(w) == 1
-            assert '/l2/W' in str(w[-1].message)
 
 
 @testing.parameterize(

--- a/tests/test_replace_func.py
+++ b/tests/test_replace_func.py
@@ -190,7 +190,7 @@ def test_replace_func_collection_return(tmpdir, return_type):
 
     addon_converters = {'xTiledArray': tiled_array_converter}
 
-    with warnings.catch_warnings(record=True):
+    with testing.assert_warns(UserWarning):
         export_testcase(model, x, path, external_converters=addon_converters)
 
     model_filepath = os.path.join(path, 'model.onnx')


### PR DESCRIPTION
- same with Chainer's pytest configuration
  - error on unexpected warning
  - ignore experimental warning
- handle `UserWarning` on testing
  - drop warning check manually